### PR TITLE
Stop on collision

### DIFF
--- a/controllers/examples/pick_up.py
+++ b/controllers/examples/pick_up.py
@@ -32,7 +32,7 @@ class PickUp(Magnebot):
                 # Keep rotating the camera.
                 status = self.rotate_camera(yaw=d_cam_theta)
             # Turn the Magnebot.
-            self.turn_by(d_turn)
+            self.turn_by(d_turn, stop_on_collision=False)
             turn += d_turn
         nearby = list(set(nearby))
         print(f"Nearby objects:")
@@ -54,7 +54,7 @@ class PickUp(Magnebot):
         print(f"Target object: {target_object}\t{self.objects_static[target_object].name}")
 
         # Move to the target object.
-        status = self.move_to(target=target_object)
+        status = self.move_to(target=target_object, stop_on_collision=False)
         print(f"Move to target object: {status}")
         # Grasp the object.
         status = self.grasp(target_object, arm=Arm.left)
@@ -74,7 +74,7 @@ class PickUp(Magnebot):
         while status == ActionStatus.collision:
             print(f"Tried moving but got status: {status}")
             # If we collided with something, back up, re-orient, and try again.
-            self.move_by(-0.5)
+            self.move_by(-0.5, stop_on_collision=False)
             self.turn_by(15)
             status = self.move_by(1)
         print(f"Moved: {status}")

--- a/controllers/examples/simple_navigation.py
+++ b/controllers/examples/simple_navigation.py
@@ -1,0 +1,47 @@
+from magnebot import Magnebot, ActionStatus
+from magnebot.collision_action import CollisionAction
+
+
+class SimpleNavigation(Magnebot):
+    """
+    A VERY simple navigation algorithm.
+    The Magnebot will choose a random move or turn action. If that action ends in failure, it won't choose it again.
+    For example, if the previous action was `move_by(1)` and it ended in failure, the next action can't be `move_by(2)`.
+    """
+
+    ACTIONS = [a for a in CollisionAction]
+
+    def run(self) -> None:
+        self.init_scene(scene="1a", layout=1, room=1)
+        # Add a camera for debugging.
+        self.add_camera(position={"x": 1.43, "y": 1.87, "z": 0.77}, look_at=True, follow=True)
+        previous_action: int = 0
+        for i in range(1000):
+            # Convert all potential actions to an integer.
+            actions: int = sum([a.value for a in CollisionAction]) - previous_action
+            # Get a list of all possible options. If the previous action was a collision, disallow it.
+            possible_actions = [a for a in SimpleNavigation.ACTIONS if actions - previous_action & a.value]
+            # Pick a random action.
+            action: CollisionAction = self._rng.choice(possible_actions)
+            if action == CollisionAction.move_positive:
+                status = self.move_by(1)
+            elif action == CollisionAction.move_negative:
+                status = self.move_by(-1)
+            elif action == CollisionAction.turn_positive:
+                status = self.turn_by(30)
+            elif action == CollisionAction.turn_negative:
+                status = self.turn_by(-30)
+            else:
+                raise Exception(f"Not defined: {action}")
+            # The action succeeded so we're allowed to try it again.
+            if status == ActionStatus.success:
+                previous_action = 0
+            # The action failed. Don't try it again.
+            else:
+                previous_action = action.value
+        self.end()
+
+
+if __name__ == "__main__":
+    m = SimpleNavigation(random_seed=0)
+    m.run()

--- a/controllers/examples/simple_navigation.py
+++ b/controllers/examples/simple_navigation.py
@@ -11,6 +11,7 @@ class SimpleNavigation(Magnebot):
     """
 
     # A list of all possible actions. Remove the first element (none).
+    # For documentation, see: `doc/api/collision_action.md`
     ACTIONS = [a for a in CollisionAction][1:]
 
     def run(self) -> None:

--- a/controllers/examples/simple_navigation.py
+++ b/controllers/examples/simple_navigation.py
@@ -1,3 +1,4 @@
+from tqdm import tqdm
 from magnebot import Magnebot, ActionStatus
 from magnebot.collision_action import CollisionAction
 
@@ -9,14 +10,17 @@ class SimpleNavigation(Magnebot):
     For example, if the previous action was `move_by(1)` and it ended in failure, the next action can't be `move_by(2)`.
     """
 
-    ACTIONS = [a for a in CollisionAction]
+    # A list of all possible actions. Remove the first element (none).
+    ACTIONS = [a for a in CollisionAction][1:]
 
     def run(self) -> None:
         self.init_scene(scene="1a", layout=1, room=1)
         # Add a camera for debugging.
         self.add_camera(position={"x": 1.43, "y": 1.87, "z": 0.77}, look_at=True, follow=True)
         previous_action: int = 0
-        for i in range(1000):
+        num_actions: int = 1000
+        pbar = tqdm(total=num_actions)
+        for i in range(num_actions):
             # Convert all potential actions to an integer.
             actions: int = sum([a.value for a in CollisionAction]) - previous_action
             # Get a list of all possible options. If the previous action was a collision, disallow it.
@@ -39,6 +43,7 @@ class SimpleNavigation(Magnebot):
             # The action failed. Don't try it again.
             else:
                 previous_action = action.value
+            pbar.update(1)
         self.end()
 
 

--- a/doc/api/collision_action.md
+++ b/doc/api/collision_action.md
@@ -1,0 +1,13 @@
+# CollisionAction
+
+`from magnebot.collision_action import CollisionAction`
+
+Definition for a move or turn action that resulted in a collision.
+
+| Value | Description |
+| --- | --- |
+| `none` |  |
+| `move_positive` |  |
+| `move_negative` |  |
+| `turn_positive` |  |
+| `turn_negative` |  |

--- a/doc/api/collision_action.md
+++ b/doc/api/collision_action.md
@@ -6,8 +6,8 @@ Definition for a move or turn action that resulted in a collision.
 
 | Value | Description |
 | --- | --- |
-| `none` |  |
-| `move_positive` |  |
-| `move_negative` |  |
-| `turn_positive` |  |
-| `turn_negative` |  |
+| `none` | There was no collision on the previous action. |
+| `move_positive` | Previous action ended in a collision and was positive movement (e.g. `move_by(1)`). |
+| `move_negative` | Previous action ended in a collision and was negative movement (e.g. `move_by(-1)`). |
+| `turn_positive` | Previous action ended in a collision and was positive turn (e.g. `turn_by(45)`). |
+| `turn_negative` | Previous action ended in a collision and was negative turn (e.g. `turn_by(-45)`). |

--- a/doc/api/magnebot_controller.md
+++ b/doc/api/magnebot_controller.md
@@ -115,7 +115,9 @@ print(m.state.magnebot_transform.position)
 
 - `camera_rpy` The current (roll, pitch, yaw) angles of the Magnebot's camera in degrees as a numpy array. This is handled outside of `self.state` because it isn't calculated using output data from the build. See: `Magnebot.CAMERA_RPY_CONSTRAINTS` and `self.rotate_camera()`
 
-- `colliding_objects` A list of objects that the Magnebot is colliding with at the end of the most recent action.
+- `colliding_objects` A list of objects that the Magnebot is currently colliding with.
+
+- `colliding_with_wall` If True, the Magnebot is currently colliding with a wall.
 
 - `objects_static` [Data for all objects in the scene that that doesn't change between frames, such as object IDs, mass, etc.](object_static.md) Key = the ID of the object..
 
@@ -278,7 +280,7 @@ Possible [return values](action_status.md):
 | --- | --- | --- | --- |
 | angle |  float |  | The target angle in degrees. Positive value = clockwise turn. |
 | aligned_at |  float  | 3 | If the difference between the current angle and the target angle is less than this value, then the action is successful. |
-| stop_on_collision |  bool  | True | If True, if the Magnebot collides with the environment or a heavy object it will stop turning. Usually this should be True; set it to False if you need the Magnebot to move away from a bad position (for example, to reverse direction if it's starting to tip over). |
+| stop_on_collision |  bool  | True | If True, if the Magnebot collides with the environment or a heavy object it will stop turning. It will also stop turn if the previous action ended in a collision and was a `turn_by()` in the same direction as this action. Usually this should be True; set it to False if you need the Magnebot to move away from a bad position (for example, to reverse direction if it's starting to tip over). |
 
 _Returns:_  An `ActionStatus` indicating if the Magnebot turned by the angle and if not, why.
 

--- a/doc/api/magnebot_controller.md
+++ b/doc/api/magnebot_controller.md
@@ -260,7 +260,7 @@ _While moving, the Magnebot might start to tip over (usually because it's holdin
 
 **`self.turn_by(angle)`**
 
-**`self.turn_by(angle, aligned_at=3)`**
+**`self.turn_by(angle, aligned_at=3, stop_on_collision=True)`**
 
 Turn the Magnebot by an angle.
 
@@ -271,12 +271,14 @@ Possible [return values](action_status.md):
 - `success`
 - `failed_to_turn`
 - `tipping`
+- `collision`
 
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | angle |  float |  | The target angle in degrees. Positive value = clockwise turn. |
 | aligned_at |  float  | 3 | If the difference between the current angle and the target angle is less than this value, then the action is successful. |
+| stop_on_collision |  bool  | True | If True, if the Magnebot collides with the environment or a heavy object it will stop turning. Usually this should be True; set it to False if you need the Magnebot to move away from a bad position (for example, to reverse direction if it's starting to tip over). |
 
 _Returns:_  An `ActionStatus` indicating if the Magnebot turned by the angle and if not, why.
 
@@ -284,7 +286,7 @@ _Returns:_  An `ActionStatus` indicating if the Magnebot turned by the angle and
 
 **`self.turn_to(target)`**
 
-**`self.turn_to(target, aligned_at=3)`**
+**`self.turn_to(target, aligned_at=3, stop_on_collision=True)`**
 
 Turn the Magnebot to face a target object or position.
 
@@ -295,12 +297,14 @@ Possible [return values](action_status.md):
 - `success`
 - `failed_to_turn`
 - `tipping`
+- `collision`
 
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | target |  Union[int, Dict[str, float] |  | Either the ID of an object or a Vector3 position. |
 | aligned_at |  float  | 3 | If the different between the current angle and the target angle is less than this value, then the action is successful. |
+| stop_on_collision |  bool  | True | If True, if the Magnebot collides with the environment or a heavy object it will stop turning. Usually this should be True; set it to False if you need the Magnebot to move away from a bad position (for example, to reverse direction if it's starting to tip over). |
 
 _Returns:_  An `ActionStatus` indicating if the Magnebot turned by the angle and if not, why.
 
@@ -308,7 +312,7 @@ _Returns:_  An `ActionStatus` indicating if the Magnebot turned by the angle and
 
 **`self.move_by(distance)`**
 
-**`self.move_by(distance, arrived_at=0.3)`**
+**`self.move_by(distance, arrived_at=0.3, stop_on_collision=True)`**
 
 Move the Magnebot forward or backward by a given distance.
 
@@ -324,6 +328,7 @@ Possible [return values](action_status.md):
 | --- | --- | --- | --- |
 | distance |  float |  | The target distance. If less than zero, the Magnebot will move backwards. |
 | arrived_at |  float  | 0.3 | If at any point during the action the difference between the target distance and distance traversed is less than this, then the action is successful. |
+| stop_on_collision |  bool  | True | If True, if the Magnebot collides with the environment or a heavy object it will stop moving. Usually this should be True; set it to False if you need the Magnebot to move away from a bad position (for example, to reverse direction if it's starting to tip over). |
 
 _Returns:_  An `ActionStatus` indicating if the Magnebot moved by `distance` and if not, why.
 
@@ -331,7 +336,7 @@ _Returns:_  An `ActionStatus` indicating if the Magnebot moved by `distance` and
 
 **`self.move_to(target)`**
 
-**`self.move_to(target, arrived_at=0.3, aligned_at=3)`**
+**`self.move_to(target, arrived_at=0.3, aligned_at=3, stop_on_collision=True)`**
 
 Move the Magnebot to a target object or position.
 
@@ -351,6 +356,7 @@ Possible [return values](action_status.md):
 | target |  Union[int, Dict[str, float] |  | Either the ID of an object or a Vector3 position. |
 | arrived_at |  float  | 0.3 | While moving, if at any point during the action the difference between the target distance and distance traversed is less than this, then the action is successful. |
 | aligned_at |  float  | 3 | While turning, if the different between the current angle and the target angle is less than this value, then the action is successful. |
+| stop_on_collision |  bool  | True | If True, if the Magnebot collides with the environment or a heavy object it will stop moving or turning. Usually this should be True; set it to False if you need the Magnebot to move away from a bad position (for example, to reverse direction if it's starting to tip over). |
 
 _Returns:_  An `ActionStatus` indicating if the Magnebot moved to the target and if not, why.
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -14,7 +14,9 @@
   - Sequential moves and turns would try to reset the torso and column positions, which is only necessary after an arm articulation action. This might've caused physics crashes because the Magnebot is briefly immovable (and regardless was unnecessarily slow). Now, if the current action is a move or turn and the previous action was also a move or a turn, the Magnebot doesn't waste time trying to reset the torso and column
     - (Backend) `_end_action()` now has an optional parameter `previous_action_was_move` which should be always True if called from a move or turn action and always be False for any other action (default is False).
 - Added field: `colliding_with_wall` If True, the Magnebot is currently colliding with a wall.
+- Added example controller: `simple_navigation.py`
 - (Backend): Added some functions to make collision detection more customizable: `_is_stoppable_collision()`, `_includes_magnebot_joint_and_object()`, and `_is_high_mass()`
+- (Backend): Added `tqdm` as a required module
 - Made this changelog more readable
 
 ## 1.0.9

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@
   - Collision detection is far more accurate, especially for walls
   - Sequential moves and turns would try to reset the torso and column positions, which is only necessary after an arm articulation action. This might've caused physics crashes because the Magnebot is briefly immovable (and regardless was unnecessarily slow). Now, if the current action is a move or turn and the previous action was also a move or a turn, the Magnebot doesn't waste time trying to reset the torso and column
     - (Backend) `_end_action()` now has an optional parameter `previous_action_was_move` which should be always True if called from a move or turn action and always be False for any other action (default is False).
+- Fixed: Rare near-infinite loop that can occur in move or turn actions due to the wheels turning very slowly for a very long time
 - Fixed: TypeError in `get_visible_objects()` if there are too many colors in the image
 - Added field: `colliding_with_wall` If True, the Magnebot is currently colliding with a wall.
 - Added example controller: `simple_navigation.py`

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,7 @@
   - Collision detection is far more accurate, especially for walls
   - Sequential moves and turns would try to reset the torso and column positions, which is only necessary after an arm articulation action. This might've caused physics crashes because the Magnebot is briefly immovable (and regardless was unnecessarily slow). Now, if the current action is a move or turn and the previous action was also a move or a turn, the Magnebot doesn't waste time trying to reset the torso and column
     - (Backend) `_end_action()` now has an optional parameter `previous_action_was_move` which should be always True if called from a move or turn action and always be False for any other action (default is False).
+- Fixed: TypeError in `get_visible_objects()` if there are too many colors in the image
 - Added field: `colliding_with_wall` If True, the Magnebot is currently colliding with a wall.
 - Added example controller: `simple_navigation.py`
 - (Backend): Added some functions to make collision detection more customizable: `_is_stoppable_collision()`, `_includes_magnebot_joint_and_object()`, and `_is_high_mass()`

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,8 +2,17 @@
 
 ## 1.1.0
 
-- By default, `turn_by()` and `turn_to()` will stop on a collision, using the exact same logic as `move_by()` and `move_to()` (previously, turn actions ignored collisions)
-- Added optional parameter `stop_on_collision` to `move_by()`, `move_to()`, `turn_by()` and `turn_to()`
+- Requires: TDW 1.8.4
+- **Fixed: Build frequently crashes to desktop.** This was due to the simulation frequently entering impossible physics states. The following changes have been made to prevent this:
+  - By default, `turn_by()` and `turn_to()` will stop on a collision, using the exact same logic as `move_by()` and `move_to()` (previously, turn actions ignored collisions)
+  - Added optional parameter `stop_on_collision` to `move_by()`, `move_to()`, `turn_by()` and `turn_to()` Set this to False to ignore collision detection during the action
+  - If the previous action was a move or turn and it ended in a collision and the next action in the same direction, it will immediately fail. For example, if `turn_by(-45)` ended in a collision, `turn_by(-70)` will immediately fail (but `move_by(-1)` might succeed).
+    - (Backend) This is handled via `self._previous_collision`, which is set to a value of a new `CollisionAction` enum class
+    - (Backend) `move_by()` and `turn_by()` have an internal function `__set_collision_action()` to set whether there was a collision and if so, what type (`none`, `move_positive`, etc.)
+  - Collision detection is far more accurate, especially for walls
+  - Sequential moves and turns would try to reset the torso and column positions, which is only necessary after an arm articulation action. This might've caused physics crashes because the Magnebot is briefly immovable (and regardless was unnecessarily slow). Now, if the current action is a move or turn and the previous action was also a move or a turn, the Magnebot doesn't waste time trying to reset the torso and column
+    - (Backend) `_end_action()` now has an optional parameter `previous_action_was_move` which should be always True if called from a move or turn action and always be False for any other action (default is False).
+- Added field: `colliding_with_wall` If True, the Magnebot is currently colliding with a wall.
 - (Backend): Added some functions to make collision detection more customizable: `_is_stoppable_collision()`, `_includes_magnebot_joint_and_object()`, and `_is_high_mass()`
 - Made this changelog more readable
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,7 @@
 ## 1.1.0
 
 - Requires: TDW 1.8.4
+  - (Fixed in TDW): `rotate_camera()` and the `pitch`, `yaw`, `roll` parameters of `add_camera()` rotate around a local axis instead of a world axis
 - **Fixed: Build frequently crashes to desktop.** This was due to the simulation frequently entering impossible physics states. The following changes have been made to prevent this:
   - By default, `turn_by()` and `turn_to()` will stop on a collision, using the exact same logic as `move_by()` and `move_to()` (previously, turn actions ignored collisions)
   - Added optional parameter `stop_on_collision` to `move_by()`, `move_to()`, `turn_by()` and `turn_to()` Set this to False to ignore collision detection during the action

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 1.0.10
+## 1.1.0
 
+- By default, `turn_by()` and `turn_to()` will stop on a collision, using the exact same logic as `move_by()` and `move_to()` (previously, turn actions ignored collisions)
+- Added optional parameter `stop_on_collision` to `move_by()`, `move_to()`, `turn_by()` and `turn_to()`
 - (Backend): Added some functions to make collision detection more customizable: `_is_stoppable_collision()`, `_includes_magnebot_joint_and_object()`, and `_is_high_mass()`
 - Made this changelog more readable
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,44 +1,35 @@
 # Changelog
 
-## 1.0.9
+## 1.0.10
 
-### `Magnebot`
+- (Backend): Added some functions to make collision detection more customizable: `_is_stoppable_collision()`, `_includes_magnebot_joint_and_object()`, and `_is_high_mass()`
+- Made this changelog more readable
+
+## 1.0.9
 
 - Added optional parameter `check_pypi_version` to the constructor
 
 ## 1.0.8
 
-### `Magnebot`
-
 - Fixed: Avatars created via `add_camera()` don't use subpixel antialiasing
 
 ## 1.0.7
-
-### `Magnebot`
 
 - Fixed: The `pitch` and `yaw` parameters of `add_camera()` are flipped (`pitch` will yaw, and `yaw` will pitch)
 
 ## 1.0.6
 
-### `Magnebot`
-
 - Fixed: Magnebot sometimes spins in circles if the target angle is close to -180 degrees
 
 ## 1.0.5
 
-### `ObjectStatic`
-
-- Fixed: `KeyError` in constructor if the object's category isn't in `categories.json`. As a fallback, the constructor will try to get the category from a record in `models_core.json`. 
+- Fixed: `KeyError` in `ObjectStatic` constructor if the object's category isn't in `categories.json`. As a fallback, the constructor will try to get the category from a record in `models_core.json`. 
 
 ## 1.0.4
-
-### `Magnebot`
 
 - Fixed: `init_scene()` doesn't clear the data from the previous simulation
 
 ## 1.0.3
-
-### `Magnebot`
 
 - Fixed: If `turn_by()` or `turn_to()` is called and the Magnebot is already aligned with the target, the function returns `failed_to_turn` (should return `success`)
 

--- a/magnebot/collision_action.py
+++ b/magnebot/collision_action.py
@@ -1,0 +1,13 @@
+from enum import Enum
+
+
+class CollisionAction(Enum):
+    """
+    Definition for a move or turn action that resulted in a collision.
+    """
+
+    none = 1
+    move_positive = 2
+    move_negative = 4
+    turn_positive = 8
+    turn_negative = 16

--- a/magnebot/collision_action.py
+++ b/magnebot/collision_action.py
@@ -6,8 +6,8 @@ class CollisionAction(Enum):
     Definition for a move or turn action that resulted in a collision.
     """
 
-    none = 1
-    move_positive = 2
-    move_negative = 4
-    turn_positive = 8
-    turn_negative = 16
+    none = 1  # There was no collision on the previous action.
+    move_positive = 2  # Previous action ended in a collision and was positive movement (e.g. `move_by(1)`).
+    move_negative = 4  # Previous action ended in a collision and was negative movement (e.g. `move_by(-1)`).
+    turn_positive = 8  # Previous action ended in a collision and was positive turn (e.g. `turn_by(45)`).
+    turn_negative = 16  # Previous action ended in a collision and was negative turn (e.g. `turn_by(-45)`).

--- a/magnebot/magnebot_controller.py
+++ b/magnebot/magnebot_controller.py
@@ -530,8 +530,7 @@ class Magnebot(FloorplanController):
             # Wait until the wheels are done turning.
             state_0 = SceneState(resp=self.communicate(commands))
             turn_done = False
-            num_frames = 0
-            while not turn_done and num_frames < 2000:
+            while not turn_done:
                 resp = self.communicate([])
                 state_1 = SceneState(resp=resp)
                 # If the Magnebot is about to tip over, stop the action and try to correct the tip.
@@ -553,14 +552,7 @@ class Magnebot(FloorplanController):
                 if not self._wheels_are_turning(state_0=state_0, state_1=state_1):
                     turn_done = True
                 state_0 = state_1
-                num_frames += 1
             wheel_state = state_0
-            # If the wheels are still turning, something weird happened. Stop trying to turn.
-            if not turn_done:
-                self._stop_wheels(state=wheel_state)
-                self._end_action(previous_action_was_move=True)
-                __set_collision_action(True)
-                return ActionStatus.failed_to_turn
             # Get the change in angle from the initial rotation.
             theta = QuaternionUtils.get_y_angle(self.state.magnebot_transform.rotation,
                                                 wheel_state.magnebot_transform.rotation)
@@ -696,8 +688,7 @@ class Magnebot(FloorplanController):
             # Wait for the wheels to stop turning.
             move_state_0 = SceneState(resp=self.communicate(commands))
             move_done = False
-            num_frames = 0
-            while not move_done and num_frames < 2000:
+            while not move_done:
                 resp = self.communicate([])
                 move_state_1 = SceneState(resp=resp)
                 # If we're about to tip over, immediately stop and try to correct the tip.
@@ -721,14 +712,7 @@ class Magnebot(FloorplanController):
                     self._end_action(previous_action_was_move=True)
                     __set_collision_action(True)
                     return ActionStatus.collision
-                num_frames += 1
             wheel_state = move_state_0
-            # If the wheels are still turning, something weird happened. Stop trying to move.
-            if not move_done:
-                self._stop_wheels(state=wheel_state)
-                self._end_action(previous_action_was_move=True)
-                __set_collision_action(True)
-                return ActionStatus.failed_to_move
             # Check if we're at the destination.
             p1 = wheel_state.magnebot_transform.position
             d = np.linalg.norm(target_position - p1)

--- a/magnebot/magnebot_controller.py
+++ b/magnebot/magnebot_controller.py
@@ -1345,7 +1345,17 @@ class Magnebot(FloorplanController):
                                            "targets": []}])
         # Send the commands (see `communicate()` for how `_next_frame_commands` are handled).
         self.state = SceneState(resp=self.communicate([]))
-
+        # Remove any held objects from the list of colliding objects.
+        temp: List[int] = list()
+        for object_id in self.colliding_objects:
+            good = True
+            for arm in self.state.held:
+                if object_id in self.state.held[arm]:
+                    good = False
+                    break
+            if good:
+                temp.append(object_id)
+        self.colliding_objects = temp
         # Save images.
         if self.auto_save_images:
             self.state.save_images(output_directory=self.images_directory)

--- a/magnebot/magnebot_controller.py
+++ b/magnebot/magnebot_controller.py
@@ -1187,9 +1187,17 @@ class Magnebot(FloorplanController):
         :return: A list of IDs of visible objects.
         """
 
-        colors = [c[1] for c in self.state.get_pil_images()["id"].getcolors(maxcolors=1024)]
-        return [o for o in self.objects_static if self.objects_static[o].segmentation_color in colors]
-
+        # Try to get unique colors with a reasonable number of max colors.
+        # If the number of colors exceeds this, `getcolors()` returns None.
+        for max_colors in [256, 512, 1024]:
+            try:
+                colors = [c[1] for c in self.state.get_pil_images()["id"].getcolors(maxcolors=max_colors)]
+                return [o for o in self.objects_static if self.objects_static[o].segmentation_color in colors]
+            except TypeError:
+                continue
+        # This should never happen, but it's better to prevent the build rom crashing.
+        return []
+        
     def end(self) -> None:
         """
         End the simulation. Terminate the build process.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ readme = readme.replace('"https://raw.githubusercontent.com/alters-mit/magnebot/
 
 setup(
     name='magnebot',
-    version="1.0.10",
+    version="1.1.0",
     description='High-level API for the Magnebot in TDW.',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
     keywords='unity simulation tdw robotics',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['tdw', 'numpy', 'ikpy', 'requests', 'matplotlib', 'pillow', "py_md_doc"],
+    install_requires=['tdw', 'numpy', 'ikpy', 'requests', 'matplotlib', 'pillow', "py_md_doc", "tqdm"],
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ readme = readme.replace('"https://raw.githubusercontent.com/alters-mit/magnebot/
 
 setup(
     name='magnebot',
-    version="1.0.9",
+    version="1.0.10",
     description='High-level API for the Magnebot in TDW.',
     long_description=readme,
     long_description_content_type='text/markdown',
@@ -27,5 +27,5 @@ setup(
     keywords='unity simulation tdw robotics',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['tdw>=1.8.2.0', 'numpy', 'ikpy', 'requests', 'matplotlib', 'pillow', "py_md_doc"],
+    install_requires=['tdw', 'numpy', 'ikpy', 'requests', 'matplotlib', 'pillow', "py_md_doc"],
 )

--- a/util/doc_gen.py
+++ b/util/doc_gen.py
@@ -6,6 +6,7 @@ if __name__ == "__main__":
     files = ["action_status.py",
              "arm.py",
              "arm_joint.py",
+             "collision_action.py",
              "joint_static.py",
              "magnebot_controller.py",
              "magnebot_static.py",


### PR DESCRIPTION
- Requires: TDW 1.8.4
  - (Fixed in TDW): `rotate_camera()` and the `pitch`, `yaw`, `roll` parameters of `add_camera()` rotate around a local axis instead of a world axis
- **Fixed: Build frequently crashes to desktop.** This was due to the simulation frequently entering impossible physics states. The following changes have been made to prevent this:
  - By default, `turn_by()` and `turn_to()` will stop on a collision, using the exact same logic as `move_by()` and `move_to()` (previously, turn actions ignored collisions)
  - Added optional parameter `stop_on_collision` to `move_by()`, `move_to()`, `turn_by()` and `turn_to()` Set this to False to ignore collision detection during the action
  - If the previous action was a move or turn and it ended in a collision and the next action in the same direction, it will immediately fail. For example, if `turn_by(-45)` ended in a collision, `turn_by(-70)` will immediately fail (but `move_by(-1)` might succeed).
    - (Backend) This is handled via `self._previous_collision`, which is set to a value of a new `CollisionAction` enum class
    - (Backend) `move_by()` and `turn_by()` have an internal function `__set_collision_action()` to set whether there was a collision and if so, what type (`none`, `move_positive`, etc.)
  - Collision detection is far more accurate, especially for walls
  - Sequential moves and turns would try to reset the torso and column positions, which is only necessary after an arm articulation action. This might've caused physics crashes because the Magnebot is briefly immovable (and regardless was unnecessarily slow). Now, if the current action is a move or turn and the previous action was also a move or a turn, the Magnebot doesn't waste time trying to reset the torso and column
    - (Backend) `_end_action()` now has an optional parameter `previous_action_was_move` which should be always True if called from a move or turn action and always be False for any other action (default is False).
- Fixed: TypeError in `get_visible_objects()` if there are too many colors in the image
- Added field: `colliding_with_wall` If True, the Magnebot is currently colliding with a wall.
- Added example controller: `simple_navigation.py`
- (Backend): Added some functions to make collision detection more customizable: `_is_stoppable_collision()`, `_includes_magnebot_joint_and_object()`, and `_is_high_mass()`
- (Backend): Added `tqdm` as a required module
- Made this changelog more readable