### PR TITLE
Fixed: 'NoneType' object has no attribute 'transform'

### DIFF
--- a/controllers/examples/magnebot/move_by.py
+++ b/controllers/examples/magnebot/move_by.py
@@ -8,6 +8,7 @@ Move the Magnebot forward by 2 meters.
 
 c = Controller()  # On a server, change this to Controller(launch_build=False)
 magnebot = Magnebot()
+c.add_ons.append(magnebot)
 c.communicate(TDWUtils.create_empty_room(12, 12))
 magnebot.move_by(2)
 while magnebot.action.status == ActionStatus.ongoing:

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+- Fixed: `'NoneType' object has no attribute 'transform'` in minimal `Magnebot` example because the add-on isn't appended to `c.add_ons`
+
 ## 2.0.0
 
 **This is a MAJOR update to the Magnebot API. Please read this changelog carefully.**

--- a/doc/manual/magnebot/overview.md
+++ b/doc/manual/magnebot/overview.md
@@ -11,6 +11,7 @@ from magnebot import Magnebot, ActionStatus
 
 c = Controller()  # On a server, change this to Controller(launch_build=False)
 magnebot = Magnebot()
+c.add_ons.append(magnebot)
 c.communicate(TDWUtils.create_empty_room(12, 12))
 magnebot.move_by(2)
 while magnebot.action.status == ActionStatus.ongoing:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ readme = re.sub(r'\[(.*?)\]\(doc/(.*?)\)', r'[\1][https://github.com/alters-mit/
 
 setup(
     name='magnebot',
-    version="2.0.0",
+    version="2.0.1",
     description='High-level API for the Magnebot in TDW.',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Closes #15 

There was a missing line in the minimal example. This example controller works:

```python
from tdw.controller import Controller
from tdw.tdw_utils import TDWUtils
from magnebot import Magnebot, ActionStatus

c = Controller()  # On a server, change this to Controller(launch_build=False)
magnebot = Magnebot()

c.add_ons.append(magnebot) # This line was missing!

c.communicate(TDWUtils.create_empty_room(12, 12))
magnebot.move_by(2)
while magnebot.action.status == ActionStatus.ongoing:
    c.communicate([])
c.communicate([])
print(magnebot.dynamic.transform.position)
c.communicate({"$type": "terminate"})
```