### PR TITLE
Slide Torso

### DIFF
--- a/controllers/tests/slide_torso.py
+++ b/controllers/tests/slide_torso.py
@@ -15,14 +15,14 @@ c.add_ons.append(m)
 c.communicate(TDWUtils.create_empty_room(12, 12))
 torso_id = m.static.arm_joints[ArmJoint.torso]
 # Slide all the way down.
-m.slide_torso(height=0)
+m.slide_torso(height=TORSO_MIN_Y)
 while m.action.status == ActionStatus.ongoing:
     c.communicate([])
 y = np.radians(m.dynamic.joints[torso_id].angles)[0]
 d = np.linalg.norm(y - TORSO_MIN_Y)
 assert d < 0.02, (y, d)
 # Slide all the way up.
-m.slide_torso(height=1)
+m.slide_torso(height=TORSO_MAX_Y)
 while m.action.status == ActionStatus.ongoing:
     c.communicate([])
 y = np.radians(m.dynamic.joints[torso_id].angles)[0]

--- a/controllers/tests/slide_torso.py
+++ b/controllers/tests/slide_torso.py
@@ -1,0 +1,31 @@
+import numpy as np
+from tdw.controller import Controller
+from tdw.tdw_utils import TDWUtils
+from magnebot import Magnebot, ActionStatus
+from magnebot.arm_joint import ArmJoint
+from magnebot.constants import TORSO_MIN_Y, TORSO_MAX_Y
+
+"""
+Test the `SlideTorso` command.
+"""
+
+c = Controller()
+m = Magnebot()
+c.add_ons.append(m)
+c.communicate(TDWUtils.create_empty_room(12, 12))
+torso_id = m.static.arm_joints[ArmJoint.torso]
+# Slide all the way down.
+m.slide_torso(height=0)
+while m.action.status == ActionStatus.ongoing:
+    c.communicate([])
+y = np.radians(m.dynamic.joints[torso_id].angles)[0]
+d = np.linalg.norm(y - TORSO_MIN_Y)
+assert d < 0.02, (y, d)
+# Slide all the way up.
+m.slide_torso(height=1)
+while m.action.status == ActionStatus.ongoing:
+    c.communicate([])
+y = np.radians(m.dynamic.joints[torso_id].angles)[0]
+d = np.linalg.norm(y - TORSO_MAX_Y)
+assert d < 0.04, (y, d)
+c.communicate({"$type": "terminate"})

--- a/doc/api/actions/slide_torso.md
+++ b/doc/api/actions/slide_torso.md
@@ -30,7 +30,7 @@ Slide the Magnebot's torso up or down.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. |
+| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
 
 #### get_initialization_commands
 

--- a/doc/api/actions/slide_torso.md
+++ b/doc/api/actions/slide_torso.md
@@ -30,7 +30,7 @@ Slide the Magnebot's torso up or down.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
+| height |  float |  | The height of the torso. Must be between `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
 
 #### get_initialization_commands
 

--- a/doc/api/actions/slide_torso.md
+++ b/doc/api/actions/slide_torso.md
@@ -1,0 +1,83 @@
+# SlideTorso
+
+`from magnebot.actions.slide_torso import SlideTorso`
+
+Slide the Magnebot's torso up or down.
+
+## Class Variables
+
+| Variable | Type | Description | Value |
+| --- | --- | --- | --- |
+| `JOINT_ORDER` | Dict[Arm, List[ArmJoint]] | The order in which joint angles will be set. | `{Arm.left: [ArmJoint.column,` |
+
+***
+
+## Fields
+
+- `status` [The current status of the action.](../action_status.md) By default, this is `ongoing` (the action isn't done).
+
+- `initialized` If True, the action has initialized. If False, the action will try to send `get_initialization_commands(resp)` on this frame.
+
+- `done` If True, this action is done and won't send any more commands.
+
+***
+
+## Functions
+
+#### \_\_init\_\_
+
+**`SlideTorso(height)`**
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. |
+
+#### get_initialization_commands
+
+**`self.get_initialization_commands(resp, static, dynamic, image_frequency)`**
+
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| resp |  List[bytes] |  | The response from the build. |
+| static |  MagnebotStatic |  | [The static Magnebot data.](../magnebot_static.md) |
+| dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
+| image_frequency |  ImageFrequency |  | [How image data will be captured during the image.](../image_frequency.md) |
+
+_Returns:_  A list of commands to initialize this action.
+
+#### set_status_after_initialization
+
+**`self.set_status_after_initialization()`**
+
+In some cases (such as camera actions) that finish on one frame, we want to set the status after sending initialization commands.
+To do so, override this method.
+
+#### get_ongoing_commands
+
+**`self.get_ongoing_commands(resp, static, dynamic)`**
+
+Evaluate an action per-frame to determine whether it's done.
+
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| resp |  List[bytes] |  | The response from the build. |
+| static |  MagnebotStatic |  | [The static Magnebot data.](../magnebot_static.md) |
+| dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
+
+_Returns:_  A list of commands to send to the build to continue the action.
+
+#### get_end_commands
+
+**`self.get_end_commands(resp, static, dynamic, image_frequency)`**
+
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| resp |  List[bytes] |  | The response from the build. |
+| static |  MagnebotStatic |  | [The static Magnebot data.](../magnebot_static.md) |
+| dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
+| image_frequency |  ImageFrequency |  | [How image data will be captured during the image.](../image_frequency.md) |
+
+_Returns:_  A list of commands that must be sent to end any action.

--- a/doc/api/magnebot.md
+++ b/doc/api/magnebot.md
@@ -362,7 +362,7 @@ Slide the Magnebot's torso up or down.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
+| height |  float |  | The height of the torso. Must be between `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
 
 ***
 

--- a/doc/api/magnebot.md
+++ b/doc/api/magnebot.md
@@ -346,6 +346,16 @@ Reset an arm to its neutral position.
 | --- | --- | --- | --- |
 | arm |  Arm |  | [The arm to reset.](arm.md) |
 
+#### slide_torso
+
+**`self.slide_torso(height)`**
+
+Slide the Magnebot's torso up or down.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. |
+
 ***
 
 ### Camera

--- a/doc/api/magnebot.md
+++ b/doc/api/magnebot.md
@@ -346,6 +346,14 @@ Reset an arm to its neutral position.
 | --- | --- | --- | --- |
 | arm |  Arm |  | [The arm to reset.](arm.md) |
 
+***
+
+### Torso
+
+These functions adjust the Magnebot's torso..
+
+During a torso action, the Magnebot is always "immovable", meaning that its wheels are locked and it isn't possible for its root object to move or rotate.
+
 #### slide_torso
 
 **`self.slide_torso(height)`**
@@ -354,13 +362,13 @@ Slide the Magnebot's torso up or down.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. |
+| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
 
 ***
 
 ### Camera
 
-These commands rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.
+These functions rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.
 
 #### rotate_camera
 

--- a/doc/api/magnebot_controller.md
+++ b/doc/api/magnebot_controller.md
@@ -364,7 +364,7 @@ Slide the Magnebot's torso up or down.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
+| height |  float |  | The height of the torso. Must be between `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
 
 _Returns:_  An `ActionStatus` (always success).
 

--- a/doc/api/magnebot_controller.md
+++ b/doc/api/magnebot_controller.md
@@ -347,6 +347,19 @@ This action should only be called if the Magnebot is a position that will preven
 
 _Returns:_  An `ActionStatus` indicating whether the Magnebot reset its arm and if not, why.
 
+#### slide_torso
+
+**`self.slide_torso(height)`**
+
+Slide the Magnebot's torso up or down.
+
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. |
+
+_Returns:_  An `ActionStatus` (always success).
+
 ***
 
 ### Camera

--- a/doc/api/magnebot_controller.md
+++ b/doc/api/magnebot_controller.md
@@ -347,6 +347,14 @@ This action should only be called if the Magnebot is a position that will preven
 
 _Returns:_  An `ActionStatus` indicating whether the Magnebot reset its arm and if not, why.
 
+***
+
+### Torso
+
+These functions adjust the Magnebot's torso..
+
+During a torso action, the Magnebot is always "immovable", meaning that its wheels are locked and it isn't possible for its root object to move or rotate.
+
 #### slide_torso
 
 **`self.slide_torso(height)`**
@@ -356,7 +364,7 @@ Slide the Magnebot's torso up or down.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. |
+| height |  float |  | A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`. |
 
 _Returns:_  An `ActionStatus` (always success).
 
@@ -364,7 +372,7 @@ _Returns:_  An `ActionStatus` (always success).
 
 ### Camera
 
-These commands rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.
+These functions rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.
 
 #### rotate_camera
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.0
+
+- Added a new action: `SlideTorso(height)`, which can be called via `magnebot.slide_torso(height)` or `magnebot_controller.slide_torso(height)`.
+
 ## 2.0.7
 
 - Fixed required version of TDW in setup.py (>=1.10.6.0)

--- a/doc/manual/magnebot/actions.md
+++ b/doc/manual/magnebot/actions.md
@@ -17,6 +17,7 @@ By default, the `Magnebot` action space is:
 - `reset_position()`
 - `rotate_camera(roll, pitch, yaw)`
 - `reset_camera()`
+- `slide_torso(height)`
 - `stop()`
 
 *Note:  Most of these actions have additional optional parameters. Read the API document for more information.*

--- a/doc/manual/magnebot/output_data.md
+++ b/doc/manual/magnebot/output_data.md
@@ -104,6 +104,8 @@ c.communicate({"$type": "terminate"})
 
 Raw image data is stored in `magnebot.dynamic.images`, a dictionary where key = pass mask (`_img`, `_id`, or `_depth`) and value = raw numpy image array.
 
+Call these functions after a `c.communicate(commands)` call.
+
 - To save the images to disk, call `magnebot.dynamic.save_images(path)`.
 - To get PIL images, call `magnebot.dynamic.get_pil_images()`
 - To get depth values, call `magnebot.dynamic.get_depth_values()`

--- a/doc/manual/magnebot_controller/actions.md
+++ b/doc/manual/magnebot_controller/actions.md
@@ -17,6 +17,7 @@ The `MagnebotController` action space is:
 - `reset_position()`
 - `rotate_camera(roll, pitch, yaw)`
 - `reset_camera()`
+- `slide_torso(height)`
 
 *Note:  Most of these actions have additional optional parameters. Read the API document for more information.*
 

--- a/doc/manual/magnebot_controller/output_data.md
+++ b/doc/manual/magnebot_controller/output_data.md
@@ -162,6 +162,8 @@ c.end()
 
 Raw image data is stored in `self.magnebot.dynamic.images`, a dictionary where key = pass mask (`_img`, `_id`, or `_depth`) and value = raw numpy image array.
 
+Call these functions after a `c.communicate(commands)` call.
+
 - To save the images to disk, call `c.magnebot.dynamic.save_images(path)`.
 - To get PIL images, call `c.magnebot.dynamic.get_pil_images()`
 - To get depth values, call `c.magnebot.dynamic.get_depth_values()`

--- a/doc_metadata.json
+++ b/doc_metadata.json
@@ -15,7 +15,7 @@
     },
     "Arm Articulation": {
       "description": "These functions move and bend the joints of the Magnebots's arms.\n\nDuring an arm articulation action, the Magnebot is always \"immovable\", meaning that its wheels are locked and it isn't possible for its root object to move or rotate.\n\nFor more information regarding how arm articulation works, [read this](../manual/magnebot_controller/arm_articulation.md).",
-      "functions": ["reach_for", "grasp", "drop", "reset_arm"]
+      "functions": ["reach_for", "grasp", "drop", "reset_arm", "slide_torso"]
     },
     "Camera": {
       "description": "These commands rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.",
@@ -42,7 +42,7 @@
     },
     "Arm Articulation": {
       "description": "These functions move and bend the joints of the Magnebots's arms.\n\nDuring an arm articulation action, the Magnebot is always \"immovable\", meaning that its wheels are locked and it isn't possible for its root object to move or rotate.\n\nFor more information regarding how arm articulation works, [read this](../manual/magnebot/arm_articulation.md).",
-      "functions": ["reach_for", "grasp", "drop", "reset_arm"]
+      "functions": ["reach_for", "grasp", "drop", "reset_arm", "slide_torso"]
     },
     "Camera": {
       "description": "These commands rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.",

--- a/doc_metadata.json
+++ b/doc_metadata.json
@@ -15,10 +15,14 @@
     },
     "Arm Articulation": {
       "description": "These functions move and bend the joints of the Magnebots's arms.\n\nDuring an arm articulation action, the Magnebot is always \"immovable\", meaning that its wheels are locked and it isn't possible for its root object to move or rotate.\n\nFor more information regarding how arm articulation works, [read this](../manual/magnebot_controller/arm_articulation.md).",
-      "functions": ["reach_for", "grasp", "drop", "reset_arm", "slide_torso"]
+      "functions": ["reach_for", "grasp", "drop", "reset_arm"]
+    },
+    "Torso": {
+      "description": "These functions adjust the Magnebot's torso..\n\nDuring a torso action, the Magnebot is always \"immovable\", meaning that its wheels are locked and it isn't possible for its root object to move or rotate.",
+      "functions": ["slide_torso"]
     },
     "Camera": {
-      "description": "These commands rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.",
+      "description": "These functions rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.",
       "functions": ["rotate_camera", "reset_camera", "add_camera"]
     },
     "Misc.": {
@@ -42,10 +46,14 @@
     },
     "Arm Articulation": {
       "description": "These functions move and bend the joints of the Magnebots's arms.\n\nDuring an arm articulation action, the Magnebot is always \"immovable\", meaning that its wheels are locked and it isn't possible for its root object to move or rotate.\n\nFor more information regarding how arm articulation works, [read this](../manual/magnebot/arm_articulation.md).",
-      "functions": ["reach_for", "grasp", "drop", "reset_arm", "slide_torso"]
+      "functions": ["reach_for", "grasp", "drop", "reset_arm"]
+    },
+    "Torso": {
+      "description": "These functions adjust the Magnebot's torso..\n\nDuring a torso action, the Magnebot is always \"immovable\", meaning that its wheels are locked and it isn't possible for its root object to move or rotate.",
+      "functions": ["slide_torso"]
     },
     "Camera": {
-      "description": "These commands rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.",
+      "description": "These functions rotate the Magnebot's camera or add additional camera to the scene. They advance the simulation by exactly 1 frame.",
       "functions": ["rotate_camera", "reset_camera", "add_camera"]
     },
     "RobotBase": {

--- a/magnebot/actions/slide_torso.py
+++ b/magnebot/actions/slide_torso.py
@@ -16,7 +16,7 @@ class SlideTorso(Action):
 
     def __init__(self, height: float):
         """
-        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest.
+        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
         """
 
         super().__init__()

--- a/magnebot/actions/slide_torso.py
+++ b/magnebot/actions/slide_torso.py
@@ -2,7 +2,6 @@ from typing import List
 import numpy as np
 from magnebot.actions.action import Action
 from magnebot.arm_joint import ArmJoint
-from magnebot.constants import TORSO_MIN_Y, TORSO_MAX_Y, COLUMN_Y
 from magnebot.magnebot_static import MagnebotStatic
 from magnebot.magnebot_dynamic import MagnebotDynamic
 from magnebot.image_frequency import ImageFrequency
@@ -16,12 +15,12 @@ class SlideTorso(Action):
 
     def __init__(self, height: float):
         """
-        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
+        :param height: The height of the torso. Must be between `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
         """
 
         super().__init__()
-        # Clamp the `height` to be within the torso position limits and then convert it to a torso value.
-        self._position: float = self._y_position_to_torso_position((COLUMN_Y + (TORSO_MAX_Y - TORSO_MIN_Y)) * height)
+        # Convert the height to a torso value.
+        self._position: float = self._y_position_to_torso_position(height)
 
     def get_initialization_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
                                     image_frequency: ImageFrequency) -> List[dict]:

--- a/magnebot/actions/slide_torso.py
+++ b/magnebot/actions/slide_torso.py
@@ -1,0 +1,57 @@
+from typing import List
+import numpy as np
+from magnebot.actions.action import Action
+from magnebot.arm_joint import ArmJoint
+from magnebot.constants import TORSO_MIN_Y, TORSO_MAX_Y, COLUMN_Y
+from magnebot.magnebot_static import MagnebotStatic
+from magnebot.magnebot_dynamic import MagnebotDynamic
+from magnebot.image_frequency import ImageFrequency
+from magnebot.action_status import ActionStatus
+
+
+class SlideTorso(Action):
+    """
+    Slide the Magnebot's torso up or down.
+    """
+
+    def __init__(self, height: float):
+        """
+        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest.
+        """
+
+        super().__init__()
+        # Clamp the `height` to be within the torso position limits and then convert it to a torso value.
+        self._position: float = self._y_position_to_torso_position((COLUMN_Y + (TORSO_MAX_Y - TORSO_MIN_Y)) * height)
+
+    def get_initialization_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
+                                    image_frequency: ImageFrequency) -> List[dict]:
+        commands = super().get_initialization_commands(resp=resp, static=static, dynamic=dynamic,
+                                                       image_frequency=image_frequency)
+        # Make the Magnebot immovable.
+        if not dynamic.immovable:
+            commands.append({"$type": "set_immovable",
+                             "immovable": True,
+                             "id": static.robot_id})
+        # Start moving the torso.
+        commands.append({"$type": "set_prismatic_target",
+                         "joint_id": static.arm_joints[ArmJoint.torso],
+                         "id": static.robot_id,
+                         "target": self._position})
+        return commands
+
+    def get_ongoing_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic) -> List[dict]:
+        # Wait until the torso stops moving.
+        if not dynamic.joints[static.arm_joints[ArmJoint.torso]].moving:
+            self.status = ActionStatus.success
+        return []
+
+    def get_end_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
+                         image_frequency: ImageFrequency) -> List[dict]:
+        commands = super().get_end_commands(resp=resp, static=static, dynamic=dynamic, image_frequency=image_frequency)
+        # Stop moving the torso.
+        joint_id = static.arm_joints[ArmJoint.torso]
+        commands.append({"$type": "set_prismatic_target",
+                         "joint_id": joint_id,
+                         "target": float(np.radians(dynamic.joints[joint_id].angles)),
+                         "id": static.robot_id})
+        return commands

--- a/magnebot/actions/slide_torso.py
+++ b/magnebot/actions/slide_torso.py
@@ -6,6 +6,7 @@ from magnebot.magnebot_static import MagnebotStatic
 from magnebot.magnebot_dynamic import MagnebotDynamic
 from magnebot.image_frequency import ImageFrequency
 from magnebot.action_status import ActionStatus
+from magnebot.constants import TORSO_MIN_Y, TORSO_MAX_Y
 
 
 class SlideTorso(Action):
@@ -20,7 +21,7 @@ class SlideTorso(Action):
 
         super().__init__()
         # Convert the height to a torso value.
-        self._position: float = self._y_position_to_torso_position(height)
+        self._position: float = self._y_position_to_torso_position(max(min(height, TORSO_MAX_Y), TORSO_MIN_Y))
 
     def get_initialization_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
                                     image_frequency: ImageFrequency) -> List[dict]:

--- a/magnebot/magnebot.py
+++ b/magnebot/magnebot.py
@@ -27,6 +27,7 @@ from magnebot.actions.reset_arm import ResetArm
 from magnebot.actions.reset_position import ResetPosition
 from magnebot.actions.rotate_camera import RotateCamera
 from magnebot.actions.reset_camera import ResetCamera
+from magnebot.actions.slide_torso import SlideTorso
 from magnebot.actions.stop import Stop
 from magnebot.actions.wait import Wait
 from magnebot.constants import TDW_VERSION
@@ -476,6 +477,15 @@ class Magnebot(RobotBase):
         self.camera_rpy: np.array = np.array([0, 0, 0])
         self.collision_detection = CollisionDetection()
         self._previous_resp.clear()
+
+    def slide_torso(self, height: float) -> None:
+        """
+        Slide the Magnebot's torso up or down.
+
+        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest.
+        """
+
+        self.action = SlideTorso(height=height)
 
     def _cache_static_data(self, resp: List[bytes]) -> None:
         """

--- a/magnebot/magnebot.py
+++ b/magnebot/magnebot.py
@@ -482,7 +482,7 @@ class Magnebot(RobotBase):
         """
         Slide the Magnebot's torso up or down.
 
-        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
+        :param height: The height of the torso. Must be between `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
         """
 
         self.action = SlideTorso(height=height)

--- a/magnebot/magnebot.py
+++ b/magnebot/magnebot.py
@@ -482,7 +482,7 @@ class Magnebot(RobotBase):
         """
         Slide the Magnebot's torso up or down.
 
-        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest.
+        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
         """
 
         self.action = SlideTorso(height=height)

--- a/magnebot/magnebot_controller.py
+++ b/magnebot/magnebot_controller.py
@@ -394,6 +394,18 @@ class MagnebotController(Controller):
         self.magnebot.reset_camera()
         return self._do_action()
 
+    def slide_torso(self, height: float) -> ActionStatus:
+        """
+        Slide the Magnebot's torso up or down.
+
+        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest.
+
+        :return: An `ActionStatus` (always success).
+        """
+
+        self.magnebot.slide_torso(height=height)
+        return self._do_action()
+
     def get_visible_objects(self) -> List[int]:
         """
         Get all objects visible to the Magnebot.

--- a/magnebot/magnebot_controller.py
+++ b/magnebot/magnebot_controller.py
@@ -398,7 +398,7 @@ class MagnebotController(Controller):
         """
         Slide the Magnebot's torso up or down.
 
-        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest.
+        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
 
         :return: An `ActionStatus` (always success).
         """

--- a/magnebot/magnebot_controller.py
+++ b/magnebot/magnebot_controller.py
@@ -398,7 +398,7 @@ class MagnebotController(Controller):
         """
         Slide the Magnebot's torso up or down.
 
-        :param height: A value between 0 and 1, where 0 is the lowest height of the torso and 1 is the highest. For the actual y values, see `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
+        :param height: The height of the torso. Must be between `magnebot.constants.TORSO_MIN_Y` and `magnebot.constants.TORSO_MAX_Y`.
 
         :return: An `ActionStatus` (always success).
         """

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ readme = re.sub(r'\[(.*?)\]\(doc/(.*?)\)', r'[\1][https://github.com/alters-mit/
 
 setup(
     name='magnebot',
-    version="2.0.7",
+    version="2.1.0",
     description='High-level API for the Magnebot in TDW.',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Added a new action: `SlideTorso(height)`, which can be called via `magnebot.slide_torso(height)` or `magnebot_controller.slide_torso(height)`.


To test:

1. `git fetch`
2. `git checkout slide_torso`
3. `cd controllers/tests`
4. `python3 slide_torso.py`