### PR TITLE
New set_torso parameter

### DIFF
--- a/doc/api/actions/arm_motion.md
+++ b/doc/api/actions/arm_motion.md
@@ -26,11 +26,12 @@ Abstract base class for arm motions.
 
 #### \_\_init\_\_
 
-**`ArmMotion(arm)`**
+**`ArmMotion(arm, set_torso)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | arm |  Arm |  | [The arm used for this action.](../arm.md) |
+| set_torso |  bool |  | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 
 #### get_initialization_commands
 

--- a/doc/api/actions/drop.md
+++ b/doc/api/actions/drop.md
@@ -32,12 +32,13 @@ Drop an object held by a magnet.
 
 #### \_\_init\_\_
 
-**`Drop(target, arm, wait_for_object, dynamic)`**
+**`Drop(target, arm, set_torso, wait_for_object, dynamic)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | target |  int |  | The ID of the object currently held by the magnet. |
 | arm |  Arm |  | [The arm used for this action.](../arm.md) |
+| set_torso |  bool |  | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 | wait_for_object |  bool |  | If True, the action will continue until the object has finished falling. If False, the action advances the simulation by exactly 1 frame. |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
 

--- a/doc/api/actions/grasp.md
+++ b/doc/api/actions/grasp.md
@@ -33,12 +33,13 @@ The action ends when either the Magnebot grasps the object, can't grasp it, or f
 
 #### \_\_init\_\_
 
-**`Grasp(target, arm, orientation_mode, target_orientation, dynamic)`**
+**`Grasp(target, arm, set_torso, orientation_mode, target_orientation, dynamic)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | target |  int |  | The ID of the target object. |
 | arm |  Arm |  | [The arm used for this action.](../arm.md) |
+| set_torso |  bool |  | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 | orientation_mode |  OrientationMode |  | [The orientation mode.](../ik/orientation_mode.md) |
 | target_orientation |  TargetOrientation |  | [The target orientation.](../ik/target_orientation.md) |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |

--- a/doc/api/actions/ik_motion.md
+++ b/doc/api/actions/ik_motion.md
@@ -32,11 +32,12 @@ Abstract base class for arm motions that utilize IK.
 
 #### \_\_init\_\_
 
-**`IKMotion(arm, orientation_mode, target_orientation, dynamic)`**
+**`IKMotion(arm, set_torso, orientation_mode, target_orientation, dynamic)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | arm |  Arm |  | [The arm used for this action.](../arm.md) |
+| set_torso |  bool |  | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 | orientation_mode |  OrientationMode |  | [The orientation mode.](../ik/orientation_mode.md) |
 | target_orientation |  TargetOrientation |  | [The target orientation.](../ik/target_orientation.md) |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |

--- a/doc/api/actions/move_by.md
+++ b/doc/api/actions/move_by.md
@@ -28,9 +28,9 @@ Move the Magnebot forward or backward by a given distance.
 
 #### \_\_init\_\_
 
-**`MoveBy(distance, dynamic, collision_detection)`**
+**`MoveBy(distance, dynamic, collision_detection, set_torso)`**
 
-**`MoveBy(distance, arrived_at=0.1, dynamic, collision_detection, previous=None)`**
+**`MoveBy(distance, arrived_at=0.1, dynamic, collision_detection, set_torso, previous=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -38,6 +38,7 @@ Move the Magnebot forward or backward by a given distance.
 | arrived_at |  float  | 0.1 | If at any point during the action the difference between the target distance and distance traversed is less than this, then the action is successful. |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
 | collision_detection |  CollisionDetection |  | [The collision detection rules.](../collision_detection.md) |
+| set_torso |  bool |  | If True, slide the torso to its default position when the wheel motion begins. |
 | previous |  Action  | None | The previous action, if any. |
 
 #### get_initialization_commands

--- a/doc/api/actions/move_to.md
+++ b/doc/api/actions/move_to.md
@@ -28,9 +28,9 @@ This action has two "sub-actions": A [`TurnBy`](turn_by.md) and a [`MoveBy`](mov
 
 #### \_\_init\_\_
 
-**`MoveTo(target, resp, dynamic, collision_detection)`**
+**`MoveTo(target, resp, dynamic, collision_detection, set_torso)`**
 
-**`MoveTo(target, resp, arrived_at=0.1, aligned_at=1, arrived_offset=0, dynamic, collision_detection, previous=None)`**
+**`MoveTo(target, resp, arrived_at=0.1, aligned_at=1, arrived_offset=0, dynamic, collision_detection, set_torso, previous=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -41,6 +41,7 @@ This action has two "sub-actions": A [`TurnBy`](turn_by.md) and a [`MoveBy`](mov
 | arrived_offset |  float  | 0 | Offset the arrival position by this value. This can be useful if the Magnebot needs to move to an object but shouldn't try to move to the object's centroid. This is distinct from `arrived_at` because it won't affect the Magnebot's braking solution. |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
 | collision_detection |  CollisionDetection |  | [The collision detection rules.](../collision_detection.md) |
+| set_torso |  bool |  | If True, slide the torso to its default position when the wheel motion begins. |
 | previous |  Action  | None | The previous action, if any. |
 
 #### get_initialization_commands

--- a/doc/api/actions/reach_for.md
+++ b/doc/api/actions/reach_for.md
@@ -45,9 +45,9 @@ The Magnebot may try to reach for the target multiple times, trying different IK
 
 #### \_\_init\_\_
 
-**`ReachFor(target, absolute, arm, orientation_mode, target_orientation, dynamic)`**
+**`ReachFor(target, absolute, arm, set_torso, orientation_mode, target_orientation, dynamic)`**
 
-**`ReachFor(target, absolute, arrived_at=0.125, arm, orientation_mode, target_orientation, dynamic)`**
+**`ReachFor(target, absolute, arrived_at=0.125, arm, set_torso, orientation_mode, target_orientation, dynamic)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -55,6 +55,7 @@ The Magnebot may try to reach for the target multiple times, trying different IK
 | absolute |  bool |  | If True, `target` is in absolute world coordinates. If `False`, `target` is relative to the position and rotation of the Magnebot. |
 | arrived_at |  float  | 0.125 | If the magnet is this distance or less from `target`, then the action is successful. |
 | arm |  Arm |  | [The arm used for this action.](../arm.md) |
+| set_torso |  bool |  | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 | orientation_mode |  OrientationMode |  | [The orientation mode.](../ik/orientation_mode.md) |
 | target_orientation |  TargetOrientation |  | [The target orientation.](../ik/target_orientation.md) |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |

--- a/doc/api/actions/reset_arm.md
+++ b/doc/api/actions/reset_arm.md
@@ -34,11 +34,12 @@ Reset an arm to its neutral position.
 
 \_\_init\_\_
 
-**`ResetArm(arm)`**
+**`ResetArm(arm, set_torso)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | arm |  Arm |  | [The arm used for this action.](../arm.md) |
+| set_torso |  bool |  | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 
 #### get_initialization_commands
 

--- a/doc/api/actions/turn.md
+++ b/doc/api/actions/turn.md
@@ -26,15 +26,16 @@ Abstract base class for a turn action.
 
 #### \_\_init\_\_
 
-**`Turn(dynamic, collision_detection)`**
+**`Turn(dynamic, collision_detection, set_torso)`**
 
-**`Turn(aligned_at=1, dynamic, collision_detection, previous=None)`**
+**`Turn(aligned_at=1, dynamic, collision_detection, set_torso, previous=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | aligned_at |  float  | 1 | If the difference between the current angle and the target angle is less than this value, then the action is successful. |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
 | collision_detection |  CollisionDetection |  | [The collision detection rules.](../collision_detection.md) |
+| set_torso |  bool |  | If True, slide the torso to its default position when the wheel motion begins. |
 | previous |  Action  | None | The previous action, if any. |
 
 #### get_initialization_commands

--- a/doc/api/actions/turn_by.md
+++ b/doc/api/actions/turn_by.md
@@ -34,15 +34,16 @@ While turning, the left wheels will turn one way and the right wheels in the opp
 
 #### \_\_init\_\_
 
-**`TurnBy(angle, dynamic, collision_detection)`**
+**`TurnBy(angle, dynamic, collision_detection, set_torso)`**
 
-**`TurnBy(angle, dynamic, collision_detection, aligned_at=1, previous=None)`**
+**`TurnBy(angle, dynamic, collision_detection, set_torso, aligned_at=1, previous=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | angle |  float |  | The target angle in degrees. Positive value = clockwise turn. |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
 | collision_detection |  CollisionDetection |  | [The collision detection rules.](../collision_detection.md) |
+| set_torso |  bool |  | If True, slide the torso to its default position when the wheel motion begins. |
 | aligned_at |  float  | 1 | If the difference between the current angle and the target angle is less than this value, then the action is successful. |
 | previous |  Action  | None | The previous action, if any. |
 

--- a/doc/api/actions/turn_to.md
+++ b/doc/api/actions/turn_to.md
@@ -36,9 +36,9 @@ Turn to a target position or object.
 
 #### \_\_init\_\_
 
-**`TurnTo(target, resp, dynamic, collision_detection)`**
+**`TurnTo(target, resp, dynamic, collision_detection, set_torso)`**
 
-**`TurnTo(target, resp, aligned_at=1, dynamic, collision_detection, previous=None)`**
+**`TurnTo(target, resp, aligned_at=1, dynamic, collision_detection, set_torso, previous=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -47,6 +47,7 @@ Turn to a target position or object.
 | aligned_at |  float  | 1 | If the difference between the current angle and the target angle is less than this value, then the action is successful. |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
 | collision_detection |  CollisionDetection |  | [The collision detection rules.](../collision_detection.md) |
+| set_torso |  bool |  | If True, slide the torso to its default position when the wheel motion begins. |
 | previous |  Action  | None | The previous action, if any. |
 
 #### get_initialization_commands

--- a/doc/api/actions/wheel_motion.md
+++ b/doc/api/actions/wheel_motion.md
@@ -26,14 +26,15 @@ Abstract base class for a motion action involving the Magnebot's wheels.
 
 #### \_\_init\_\_
 
-**`WheelMotion(dynamic, collision_detection)`**
+**`WheelMotion(dynamic, collision_detection, set_torso)`**
 
-**`WheelMotion(dynamic, collision_detection, previous=None)`**
+**`WheelMotion(dynamic, collision_detection, set_torso, previous=None)`**
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | dynamic |  MagnebotDynamic |  | [The dynamic Magnebot data.](../magnebot_dynamic.md) |
 | collision_detection |  CollisionDetection |  | [The collision detection rules.](../collision_detection.md) |
+| set_torso |  bool |  | If True, slide the torso to its default position when the wheel motion begins. |
 | previous |  Action  | None | The previous action, if any. |
 
 #### get_initialization_commands

--- a/doc/api/magnebot.md
+++ b/doc/api/magnebot.md
@@ -210,7 +210,7 @@ These functions move or turn the Magnebot. [Read this for more information about
 
 **`self.turn_by(angle)`**
 
-**`self.turn_by(angle, aligned_at=1)`**
+**`self.turn_by(angle, aligned_at=1, set_torso=True)`**
 
 Turn the Magnebot by an angle.
 
@@ -220,12 +220,13 @@ While turning, the left wheels will turn one way and the right wheels in the opp
 | --- | --- | --- | --- |
 | angle |  float |  | The target angle in degrees. Positive value = clockwise turn. |
 | aligned_at |  float  | 1 | If the difference between the current angle and the target angle is less than this value, then the action is successful. |
+| set_torso |  bool  | True | If True, slide the torso to its default position when the wheel motion begins. |
 
 #### turn_to
 
 **`self.turn_to(target)`**
 
-**`self.turn_to(target, aligned_at=1)`**
+**`self.turn_to(target, aligned_at=1, set_torso=True)`**
 
 Turn the Magnebot to face a target object or position.
 
@@ -235,12 +236,13 @@ While turning, the left wheels will turn one way and the right wheels in the opp
 | --- | --- | --- | --- |
 | target |  Union[int, Dict[str, float] |  | The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array. |
 | aligned_at |  float  | 1 | If the difference between the current angle and the target angle is less than this value, then the action is successful. |
+| set_torso |  bool  | True | If True, slide the torso to its default position when the wheel motion begins. |
 
 #### move_by
 
 **`self.move_by(distance)`**
 
-**`self.move_by(distance, arrived_at=0.1)`**
+**`self.move_by(distance, arrived_at=0.1, set_torso=True)`**
 
 Move the Magnebot forward or backward by a given distance.
 
@@ -248,12 +250,13 @@ Move the Magnebot forward or backward by a given distance.
 | --- | --- | --- | --- |
 | distance |  float |  | The target distance. If less than zero, the Magnebot will move backwards. |
 | arrived_at |  float  | 0.1 | If at any point during the action the difference between the target distance and distance traversed is less than this, then the action is successful. |
+| set_torso |  bool  | True | If True, slide the torso to its default position when the wheel motion begins. |
 
 #### move_to
 
 **`self.move_to(target)`**
 
-**`self.move_to(target, arrived_at=0.1, aligned_at=1, arrived_offset=0)`**
+**`self.move_to(target, arrived_at=0.1, aligned_at=1, arrived_offset=0, set_torso=True)`**
 
 Move to a target object or position. This combines turn_to() followed by move_by().
 
@@ -263,6 +266,7 @@ Move to a target object or position. This combines turn_to() followed by move_by
 | arrived_at |  float  | 0.1 | If at any point during the action the difference between the target distance and distance traversed is less than this, then the action is successful. |
 | aligned_at |  float  | 1 | If the difference between the current angle and the target angle is less than this value, then the action is successful. |
 | arrived_offset |  float  | 0 | Offset the arrival position by this value. This can be useful if the Magnebot needs to move to an object but shouldn't try to move to the object's centroid. This is distinct from `arrived_at` because it won't affect the Magnebot's braking solution. |
+| set_torso |  bool  | True | If True, slide the torso to its default position when the wheel motion begins. |
 
 #### stop
 
@@ -295,7 +299,7 @@ For more information regarding how arm articulation works, [read this](../manual
 
 **`self.reach_for(target, arm)`**
 
-**`self.reach_for(target, arm, absolute=True, arrived_at=0.125, orientation_mode=OrientationMode.auto, target_orientation=TargetOrientation.auto)`**
+**`self.reach_for(target, arm, absolute=True, arrived_at=0.125, orientation_mode=OrientationMode.auto, target_orientation=TargetOrientation.auto, set_torso=True)`**
 
 Reach for a target position. The action ends when the magnet is at or near the target position, or if it fails to reach the target.
 The Magnebot may try to reach for the target multiple times, trying different IK orientations each time, or no times, if it knows the action will fail.
@@ -308,12 +312,13 @@ The Magnebot may try to reach for the target multiple times, trying different IK
 | arrived_at |  float  | 0.125 | If the magnet is this distance or less from `target`, then the action is successful. |
 | orientation_mode |  OrientationMode  | OrientationMode.auto | [The orientation mode.](ik/orientation_mode.md) |
 | target_orientation |  TargetOrientation  | TargetOrientation.auto | [The target orientation.](ik/target_orientation.md) |
+| set_torso |  bool  | True | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 
 #### grasp
 
 **`self.grasp(target, arm)`**
 
-**`self.grasp(target, arm, orientation_mode=OrientationMode.auto, target_orientation=TargetOrientation.auto)`**
+**`self.grasp(target, arm, orientation_mode=OrientationMode.auto, target_orientation=TargetOrientation.auto, set_torso=True)`**
 
 Try to grasp a target object.
 The action ends when either the Magnebot grasps the object, can't grasp it, or fails arm articulation.
@@ -324,12 +329,13 @@ The action ends when either the Magnebot grasps the object, can't grasp it, or f
 | arm |  Arm |  | [The arm that will reach for and grasp the target.](arm.md) |
 | orientation_mode |  OrientationMode  | OrientationMode.auto | [The orientation mode.](ik/orientation_mode.md) |
 | target_orientation |  TargetOrientation  | TargetOrientation.auto | [The target orientation.](ik/target_orientation.md) |
+| set_torso |  bool  | True | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 
 #### drop
 
 **`self.drop(target, arm)`**
 
-**`self.drop(target, arm, wait_for_object=True)`**
+**`self.drop(target, arm, wait_for_object=True, set_torso=True)`**
 
 Drop an object held by a magnet.
 
@@ -338,16 +344,20 @@ Drop an object held by a magnet.
 | target |  int |  | The ID of the object currently held by the magnet. |
 | arm |  Arm |  | [The arm of the magnet holding the object.](arm.md) |
 | wait_for_object |  bool  | True | If True, the action will continue until the object has finished falling. If False, the action advances the simulation by exactly 1 frame. |
+| set_torso |  bool  | True | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 
 #### reset_arm
 
 **`self.reset_arm(arm)`**
+
+**`self.reset_arm(arm, set_torso=True)`**
 
 Reset an arm to its neutral position.
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
 | arm |  Arm |  | [The arm to reset.](arm.md) |
+| set_torso |  bool  | True | If True, stop sliding the torso when the arms stop moving at the end of the action. |
 
 ***
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.3
+
+- In `Magnebot`, added optional parameter `set_torso` to `drop()`, `grasp()`, `reach_for()`, and `reset_arm()`. The default value is True. If False, the torso won't be set at the *end* of the action.
+- In `Magnebot`, added optional parameter `set_torso` to `move_by()`, `move_to()`, `turn_by()`, and `turn_to()`. The default value is True. If False the torso won't slide to its default position at the *start* of the action.
+- `magnebot.slide_torso()` no longer sets the torso position at the end of the action.
+- Updated documentation to explain the `set_torso` parameter:
+  - `manual/magnebot/arm_articulation.md`
+  - `manual/magnebot/grasp.md`
+  - `manual/magnebot/movement.md`
+
 ## 2.2.2
 
 - Added optional parameter `visual_camera_mesh_scale` to the Magnebot constructor.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,6 +9,7 @@
   - `manual/magnebot/arm_articulation.md`
   - `manual/magnebot/grasp.md`
   - `manual/magnebot/movement.md`
+- Required version of TDW is now >=1.11.3.0
 
 ## 2.2.2
 

--- a/doc/manual/actions/overview.md
+++ b/doc/manual/actions/overview.md
@@ -416,7 +416,7 @@ The base `Action` class includes various hidden functions that are used by its s
 | `_get_stop_wheels_commands(static: MagnebotStatic, dynamic: MagnebotDynamic)` | Returns a list of commands that will stop the wheels at their present angles. |
 | `_y_position_to_torso_position(y_position: float)`           | Static function. Converts a `y` worldspace coordinate value to a torso prismatic joint position. |
 | `_get_initial_angles(arm: Arm, static: MagnebotStatic, dynamic: MagnebotDynamic)` | Static function. Returns a numpy array of the current angles of the joints in the given arm in radians. |
-| `_get_stop_arm_commands(arm: Arm, static: MagnebotStatic, dynamic: MagnebotDynamic)` | Static function. Returns a list of commands to stop the arm's joints at their present angles (including the column and the prismatic torso joint). |
+| `_get_stop_arm_commands(arm: Arm, static: MagnebotStatic, dynamic: MagnebotDynamic, set_torso: bool)` | Static function. Returns a list of commands to stop the arm's joints at their present angles (including the column and the prismatic torso joint). |
 | `_get_reset_arm_commands(arm: Arm, static: MagnebotStatic)`  | Static function. Returns a list of commands to reset the arm to its neutral position. |
 
 ***

--- a/doc/manual/magnebot/arm_articulation.md
+++ b/doc/manual/magnebot/arm_articulation.md
@@ -126,6 +126,10 @@ Some guidelines regarding the orientation parameters:
 
 The `arrived_at` parameter in the `reach_for()` action determines minimum distance from the magnet to the target. The action immediately stops if the magnet is within this distance. Increasing `arrived_at` therefore "improves" the success rate of an IK action.
 
+## Resetting the torso
+
+By default, the Magnebot's torso target position is set to its current position at the end of the action. Due to a 1-frame delay in the output data, this sometimes causes the torso to drop slightly. To prevent this, set `set_torso=False`. For example: `magnebot.reach_for(target=target, arm=Arm.right, set_torso=False)`.
+
 ***
 
 **Next: [Grasp action](grasp.md)**

--- a/doc/manual/magnebot/grasp.md
+++ b/doc/manual/magnebot/grasp.md
@@ -51,9 +51,13 @@ magnebot
 object
 ```
 
-### Automatic IK orientation solver
+## Automatic IK orientation solver
 
 Like `reach_for(target, arm)`, `grasp(target, arm)` has optional `target_orientation` and `orientation_mode` parameters. [Read this for more information.](arm_articulation.md)
+
+## Resetting the torso
+
+By default, the Magnebot's torso target position is set to its current position at the end of the action. Due to a 1-frame delay in the output data, this sometimes causes the torso to drop slightly. To prevent this, set `set_torso=False`. For example: `magnebot.grasp(target=1, arm=Arm.right, set_torso=False)`.
 
 ***
 

--- a/doc/manual/magnebot/movement.md
+++ b/doc/manual/magnebot/movement.md
@@ -126,6 +126,10 @@ ActionStatus.collision
 ActionStatus.success
 ```
 
+## Resetting the torso
+
+By default, all wheel motion actions (`move_by`, `move_to`, `turn_by`, and `turn_to`) will reset the Magnebot's torso to its default position and the Magenbot's column to its default rotation before moving. In some cases, you might want to keep the Magnebot's  torso at its current position, in which case you can set `set_torso=False`. For example: `magnebot.move_by(distance=2, set_torso=False)`. The Magnebot's column always resets to its default rotation, regardless of the `set_torso` value.
+
 ## Tipping over
 
 While moving or turning, the Magnebot might start to tip over. This  can happen if the Magnebot is holding a heavy object, or if its wheels roll over a ramp-like surface, etc. If this happens, the action will  immediately halt and set its status to `ActionStatus.tipping`.

--- a/magnebot/actions/action.py
+++ b/magnebot/actions/action.py
@@ -11,7 +11,7 @@ from magnebot.action_status import ActionStatus
 from magnebot.magnebot_static import MagnebotStatic
 from magnebot.magnebot_dynamic import MagnebotDynamic
 from magnebot.image_frequency import ImageFrequency
-from magnebot.constants import TORSO_MAX_Y, TORSO_MIN_Y
+from magnebot.constants import TORSO_MAX_Y, TORSO_MIN_Y, DEFAULT_TORSO_Y
 
 
 class Action(ABC):
@@ -227,10 +227,14 @@ class Action(ABC):
                                  "id": static.robot_id})
             # Convert the current prismatic "angle" back into "radians".
             elif joint_type == JointType.prismatic:
-                commands.append({"$type": "set_prismatic_target",
-                                 "joint_id": joint_id,
-                                 "target": float(np.radians(angles[0])),
-                                 "id": static.robot_id})
+                """
+                Removed because we don't want to drop the torso when drop() is called
+                """
+                continue
+                #commands.append({"$type": "set_prismatic_target",
+                #                 "joint_id": joint_id,
+                #                 "target": float(np.radians(angles[0])),
+                #                 "id": static.robot_id})
             # Set each spherical drive axis.
             elif joint_type == JointType.spherical:
                 commands.append({"$type": "set_spherical_target",
@@ -249,7 +253,6 @@ class Action(ABC):
 
         :return: A list of commands to reset the arm.
         """
-
         commands = [{"$type": "set_prismatic_target",
                      "joint_id": static.arm_joints[ArmJoint.torso],
                      "target": 1,

--- a/magnebot/actions/arm_motion.py
+++ b/magnebot/actions/arm_motion.py
@@ -13,16 +13,16 @@ class ArmMotion(Action, ABC):
     Abstract base class for arm motions.
     """
 
-    def __init__(self, arm: Arm, set_torso_at_end: bool):
+    def __init__(self, arm: Arm, set_torso: bool):
         """
         :param arm: [The arm used for this action.](../arm.md)
-        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         """
 
         super().__init__()
         # The arm used for the action.
         self._arm: Arm = arm
-        self._set_torso_at_end: bool = set_torso_at_end
+        self._set_torso: bool = set_torso
 
     def get_initialization_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
                                     image_frequency: ImageFrequency) -> List[dict]:
@@ -39,7 +39,7 @@ class ArmMotion(Action, ABC):
                          image_frequency: ImageFrequency) -> List[dict]:
         commands = super().get_end_commands(resp=resp, static=static, dynamic=dynamic, image_frequency=image_frequency)
         commands.extend(self._get_stop_arm_commands(arm=self._arm, static=static, dynamic=dynamic,
-                                                    set_torso=self._set_torso_at_end))
+                                                    set_torso=self._set_torso))
         return commands
 
     @final

--- a/magnebot/actions/arm_motion.py
+++ b/magnebot/actions/arm_motion.py
@@ -13,14 +13,16 @@ class ArmMotion(Action, ABC):
     Abstract base class for arm motions.
     """
 
-    def __init__(self, arm: Arm):
+    def __init__(self, arm: Arm, set_torso_at_end: bool):
         """
         :param arm: [The arm used for this action.](../arm.md)
+        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
         """
 
         super().__init__()
         # The arm used for the action.
         self._arm: Arm = arm
+        self._set_torso_at_end: bool = set_torso_at_end
 
     def get_initialization_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
                                     image_frequency: ImageFrequency) -> List[dict]:
@@ -36,7 +38,8 @@ class ArmMotion(Action, ABC):
     def get_end_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
                          image_frequency: ImageFrequency) -> List[dict]:
         commands = super().get_end_commands(resp=resp, static=static, dynamic=dynamic, image_frequency=image_frequency)
-        commands.extend(self._get_stop_arm_commands(arm=self._arm, static=static, dynamic=dynamic))
+        commands.extend(self._get_stop_arm_commands(arm=self._arm, static=static, dynamic=dynamic,
+                                                    set_torso=self._set_torso_at_end))
         return commands
 
     @final

--- a/magnebot/actions/drop.py
+++ b/magnebot/actions/drop.py
@@ -15,16 +15,16 @@ class Drop(ArmMotion):
     Drop an object held by a magnet.
     """
 
-    def __init__(self, target: int, arm: Arm, set_torso_at_end: bool, wait_for_object: bool, dynamic: MagnebotDynamic):
+    def __init__(self, target: int, arm: Arm, set_torso: bool, wait_for_object: bool, dynamic: MagnebotDynamic):
         """
         :param target: The ID of the object currently held by the magnet.
         :param arm: [The arm used for this action.](../arm.md)
-        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         :param wait_for_object: If True, the action will continue until the object has finished falling. If False, the action advances the simulation by exactly 1 frame.
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         """
 
-        super().__init__(arm=arm, set_torso_at_end=set_torso_at_end)
+        super().__init__(arm=arm, set_torso=set_torso)
         self._target: int = int(target)
         self._wait_for_object: bool = wait_for_object
         self._object_position: np.array = np.array([0, 0, 0])

--- a/magnebot/actions/drop.py
+++ b/magnebot/actions/drop.py
@@ -15,15 +15,16 @@ class Drop(ArmMotion):
     Drop an object held by a magnet.
     """
 
-    def __init__(self, target: int, arm: Arm, wait_for_object: bool, dynamic: MagnebotDynamic):
+    def __init__(self, target: int, arm: Arm, set_torso_at_end: bool, wait_for_object: bool, dynamic: MagnebotDynamic):
         """
         :param target: The ID of the object currently held by the magnet.
         :param arm: [The arm used for this action.](../arm.md)
+        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
         :param wait_for_object: If True, the action will continue until the object has finished falling. If False, the action advances the simulation by exactly 1 frame.
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         """
 
-        super().__init__(arm=arm)
+        super().__init__(arm=arm, set_torso_at_end=set_torso_at_end)
         self._target: int = int(target)
         self._wait_for_object: bool = wait_for_object
         self._object_position: np.array = np.array([0, 0, 0])

--- a/magnebot/actions/grasp.py
+++ b/magnebot/actions/grasp.py
@@ -34,18 +34,19 @@ class Grasp(IKMotion):
     # The order of bounds sides. The values in `_CONVEX_SIDES` correspond to indices in this list.
     _BOUNDS_SIDES: List[str] = ["left", "right", "front", "back", "top", "bottom"]
 
-    def __init__(self, target: int, arm: Arm, orientation_mode: OrientationMode, target_orientation: TargetOrientation,
-                 dynamic: MagnebotDynamic):
+    def __init__(self, target: int, arm: Arm, set_torso_at_end: bool, orientation_mode: OrientationMode,
+                 target_orientation: TargetOrientation, dynamic: MagnebotDynamic):
         """
         :param target: The ID of the target object.
         :param arm: [The arm used for this action.](../arm.md)
+        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
         :param orientation_mode: [The orientation mode.](../ik/orientation_mode.md)
         :param target_orientation: [The target orientation.](../ik/target_orientation.md)
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         """
 
-        super().__init__(arm=arm, orientation_mode=orientation_mode, target_orientation=target_orientation,
-                         dynamic=dynamic)
+        super().__init__(arm=arm, set_torso_at_end=set_torso_at_end, orientation_mode=orientation_mode,
+                         target_orientation=target_orientation, dynamic=dynamic)
         self._target: int = target
         self._grasp_status: _GraspStatus = _GraspStatus.getting_bounds
         self._target_bounds: Dict[str, np.array] = dict()

--- a/magnebot/actions/grasp.py
+++ b/magnebot/actions/grasp.py
@@ -34,18 +34,18 @@ class Grasp(IKMotion):
     # The order of bounds sides. The values in `_CONVEX_SIDES` correspond to indices in this list.
     _BOUNDS_SIDES: List[str] = ["left", "right", "front", "back", "top", "bottom"]
 
-    def __init__(self, target: int, arm: Arm, set_torso_at_end: bool, orientation_mode: OrientationMode,
+    def __init__(self, target: int, arm: Arm, set_torso: bool, orientation_mode: OrientationMode,
                  target_orientation: TargetOrientation, dynamic: MagnebotDynamic):
         """
         :param target: The ID of the target object.
         :param arm: [The arm used for this action.](../arm.md)
-        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         :param orientation_mode: [The orientation mode.](../ik/orientation_mode.md)
         :param target_orientation: [The target orientation.](../ik/target_orientation.md)
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         """
 
-        super().__init__(arm=arm, set_torso_at_end=set_torso_at_end, orientation_mode=orientation_mode,
+        super().__init__(arm=arm, set_torso=set_torso, orientation_mode=orientation_mode,
                          target_orientation=target_orientation, dynamic=dynamic)
         self._target: int = target
         self._grasp_status: _GraspStatus = _GraspStatus.getting_bounds

--- a/magnebot/actions/ik_motion.py
+++ b/magnebot/actions/ik_motion.py
@@ -37,11 +37,11 @@ class IKMotion(ArmMotion, ABC):
     # When sliding the torso first (i.e. to reach an object above the Magnebot's shoulder height), slide it slightly higher than the target.
     _EXTRA_TORSO_HEIGHT: float = 0.05
 
-    def __init__(self, arm: Arm, set_torso_at_end: bool,  orientation_mode: OrientationMode,
+    def __init__(self, arm: Arm, set_torso: bool, orientation_mode: OrientationMode,
                  target_orientation: TargetOrientation, dynamic: MagnebotDynamic):
         """
         :param arm: [The arm used for this action.](../arm.md)
-        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         :param orientation_mode: [The orientation mode.](../ik/orientation_mode.md)
         :param target_orientation: [The target orientation.](../ik/target_orientation.md)
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
@@ -52,7 +52,7 @@ class IKMotion(ArmMotion, ABC):
             IKMotion._IK_CHAINS = {Arm.left: Chain(name=Arm.left.name, links=IKMotion._get_ik_links(Arm.left)),
                                    Arm.right: Chain(name=Arm.right.name, links=IKMotion._get_ik_links(Arm.right))}
 
-        super().__init__(arm=arm, set_torso_at_end=set_torso_at_end)
+        super().__init__(arm=arm, set_torso=set_torso)
         # The action immediately ends if the Magnebot is tipping.
         has_tipped, is_tipping = self._is_tipping(dynamic=dynamic)
         if has_tipped or is_tipping:

--- a/magnebot/actions/ik_motion.py
+++ b/magnebot/actions/ik_motion.py
@@ -37,10 +37,11 @@ class IKMotion(ArmMotion, ABC):
     # When sliding the torso first (i.e. to reach an object above the Magnebot's shoulder height), slide it slightly higher than the target.
     _EXTRA_TORSO_HEIGHT: float = 0.05
 
-    def __init__(self, arm: Arm, orientation_mode: OrientationMode, target_orientation: TargetOrientation,
-                 dynamic: MagnebotDynamic):
+    def __init__(self, arm: Arm, set_torso_at_end: bool,  orientation_mode: OrientationMode,
+                 target_orientation: TargetOrientation, dynamic: MagnebotDynamic):
         """
         :param arm: [The arm used for this action.](../arm.md)
+        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
         :param orientation_mode: [The orientation mode.](../ik/orientation_mode.md)
         :param target_orientation: [The target orientation.](../ik/target_orientation.md)
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
@@ -51,7 +52,7 @@ class IKMotion(ArmMotion, ABC):
             IKMotion._IK_CHAINS = {Arm.left: Chain(name=Arm.left.name, links=IKMotion._get_ik_links(Arm.left)),
                                    Arm.right: Chain(name=Arm.right.name, links=IKMotion._get_ik_links(Arm.right))}
 
-        super().__init__(arm=arm)
+        super().__init__(arm=arm, set_torso_at_end=set_torso_at_end)
         # The action immediately ends if the Magnebot is tipping.
         has_tipped, is_tipping = self._is_tipping(dynamic=dynamic)
         if has_tipped or is_tipping:

--- a/magnebot/actions/move_by.py
+++ b/magnebot/actions/move_by.py
@@ -19,12 +19,13 @@ class MoveBy(WheelMotion):
     _BRAKE_DISTANCE: float = 0.1
 
     def __init__(self, distance: float, dynamic: MagnebotDynamic, collision_detection: CollisionDetection,
-                 arrived_at: float = 0.1, previous: Action = None):
+                 set_torso: bool, arrived_at: float = 0.1, previous: Action = None):
         """
         :param distance: The target distance.
         :param arrived_at: If at any point during the action the difference between the target distance and distance traversed is less than this, then the action is successful.
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         :param collision_detection: [The collision detection rules.](../collision_detection.md)
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         :param previous: The previous action, if any.
         """
 
@@ -33,7 +34,7 @@ class MoveBy(WheelMotion):
         """
         self.distance: float = distance
         self._arrived_at: float = arrived_at
-        super().__init__(dynamic=dynamic, collision_detection=collision_detection, previous=previous)
+        super().__init__(dynamic=dynamic, collision_detection=collision_detection, previous=previous, set_torso=set_torso)
         # Get the initial state.
         self._initial_position_arr: np.array = np.array(dynamic.transform.position[:])
         self._initial_position_v3: Dict[str, float] = TDWUtils.array_to_vector3(self._initial_position_arr)

--- a/magnebot/actions/reach_for.py
+++ b/magnebot/actions/reach_for.py
@@ -16,20 +16,21 @@ class ReachFor(IKMotion):
     The Magnebot may try to reach for the target multiple times, trying different IK orientations each time, or no times, if it knows the action will fail.
     """
 
-    def __init__(self, target: np.array, absolute: bool, arm: Arm, orientation_mode: OrientationMode,
+    def __init__(self, target: np.array, absolute: bool, arm: Arm, set_torso: bool, orientation_mode: OrientationMode,
                  target_orientation: TargetOrientation, dynamic: MagnebotDynamic, arrived_at: float = 0.125):
         """
         :param target: The target position.
         :param absolute: If True, `target` is in absolute world coordinates. If `False`, `target` is relative to the position and rotation of the Magnebot.
         :param arrived_at: If the magnet is this distance or less from `target`, then the action is successful.
         :param arm: [The arm used for this action.](../arm.md)
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         :param orientation_mode: [The orientation mode.](../ik/orientation_mode.md)
         :param target_orientation: [The target orientation.](../ik/target_orientation.md)
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         """
 
-        super().__init__(arm=arm, orientation_mode=orientation_mode, target_orientation=target_orientation,
-                         dynamic=dynamic)
+        super().__init__(arm=arm, set_torso=set_torso, orientation_mode=orientation_mode,
+                         target_orientation=target_orientation, dynamic=dynamic)
         if absolute:
             target = self._absolute_to_relative(position=target, dynamic=dynamic)
         self._target_arr: np.array = target

--- a/magnebot/actions/slide_torso.py
+++ b/magnebot/actions/slide_torso.py
@@ -50,10 +50,13 @@ class SlideTorso(Action):
     def get_end_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
                          image_frequency: ImageFrequency) -> List[dict]:
         commands = super().get_end_commands(resp=resp, static=static, dynamic=dynamic, image_frequency=image_frequency)
+        """
+        Remove because the torso does not need to drop after moved
+        """
         # Stop moving the torso.
-        joint_id = static.arm_joints[ArmJoint.torso]
-        commands.append({"$type": "set_prismatic_target",
-                         "joint_id": joint_id,
-                         "target": float(np.radians(dynamic.joints[joint_id].angles)),
-                         "id": static.robot_id})
+        #joint_id = static.arm_joints[ArmJoint.torso]
+        #commands.append({"$type": "set_prismatic_target",
+        #                 "joint_id": joint_id,
+        #                 "target": float(np.radians(dynamic.joints[joint_id].angles)),
+        #                 "id": static.robot_id})
         return commands

--- a/magnebot/actions/slide_torso.py
+++ b/magnebot/actions/slide_torso.py
@@ -1,5 +1,4 @@
 from typing import List
-import numpy as np
 from magnebot.actions.action import Action
 from magnebot.arm_joint import ArmJoint
 from magnebot.magnebot_static import MagnebotStatic
@@ -46,17 +45,3 @@ class SlideTorso(Action):
         if not dynamic.joints[static.arm_joints[ArmJoint.torso]].moving:
             self.status = ActionStatus.success
         return []
-
-    def get_end_commands(self, resp: List[bytes], static: MagnebotStatic, dynamic: MagnebotDynamic,
-                         image_frequency: ImageFrequency) -> List[dict]:
-        commands = super().get_end_commands(resp=resp, static=static, dynamic=dynamic, image_frequency=image_frequency)
-        """
-        Remove because the torso does not need to drop after moved
-        """
-        # Stop moving the torso.
-        #joint_id = static.arm_joints[ArmJoint.torso]
-        #commands.append({"$type": "set_prismatic_target",
-        #                 "joint_id": joint_id,
-        #                 "target": float(np.radians(dynamic.joints[joint_id].angles)),
-        #                 "id": static.robot_id})
-        return commands

--- a/magnebot/actions/stop.py
+++ b/magnebot/actions/stop.py
@@ -18,7 +18,7 @@ class Stop(Action):
                                                        image_frequency=image_frequency)
         commands.extend(self._get_stop_wheels_commands(static=static, dynamic=dynamic))
         for arm in [Arm.left, Arm.right]:
-            commands.extend(self._get_stop_arm_commands(arm=arm, static=static, dynamic=dynamic))
+            commands.extend(self._get_stop_arm_commands(arm=arm, static=static, dynamic=dynamic, set_torso=True))
         # Make the Magnebot immovable.
         if not dynamic.immovable:
             commands.append({"$type": "set_immovable",

--- a/magnebot/actions/turn.py
+++ b/magnebot/actions/turn.py
@@ -33,17 +33,19 @@ class Turn(WheelMotion, ABC):
                                                                outer_track=float(row["outer_track"]),
                                                                front=float(row["front"]))
 
-    def __init__(self, dynamic: MagnebotDynamic, collision_detection: CollisionDetection, aligned_at: float = 1,
-                 previous: Action = None):
+    def __init__(self, dynamic: MagnebotDynamic, collision_detection: CollisionDetection, set_torso: bool,
+                 aligned_at: float = 1, previous: Action = None):
         """
         :param aligned_at: If the difference between the current angle and the target angle is less than this value, then the action is successful.
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         :param collision_detection: [The collision detection rules.](../collision_detection.md)
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         :param previous: The previous action, if any.
         """
 
         self._angle = self._get_angle(dynamic=dynamic)
-        super().__init__(dynamic=dynamic, collision_detection=collision_detection, previous=previous)
+        super().__init__(dynamic=dynamic, collision_detection=collision_detection, set_torso=set_torso,
+                         previous=previous)
         self._clamp_angle()
         self._aligned_at: float = aligned_at
         self._max_attempts: int = int((np.abs(self._angle) + 1) / 2)

--- a/magnebot/actions/turn_by.py
+++ b/magnebot/actions/turn_by.py
@@ -12,19 +12,20 @@ class TurnBy(Turn):
     While turning, the left wheels will turn one way and the right wheels in the opposite way, allowing the Magnebot to turn in place.
     """
 
-    def __init__(self, angle: float, dynamic: MagnebotDynamic, collision_detection: CollisionDetection,
+    def __init__(self, angle: float, dynamic: MagnebotDynamic, collision_detection: CollisionDetection, set_torso: bool,
                  aligned_at: float = 1, previous: Action = None):
         """
         :param angle: The target angle in degrees. Positive value = clockwise turn.
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         :param collision_detection: [The collision detection rules.](../collision_detection.md)
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         :param aligned_at: If the difference between the current angle and the target angle is less than this value, then the action is successful.
         :param previous: The previous action, if any.
         """
 
         self.__angle: float = angle
         super().__init__(aligned_at=aligned_at, dynamic=dynamic, collision_detection=collision_detection,
-                         previous=previous)
+                         set_torso=set_torso, previous=previous)
 
     def _get_angle(self, dynamic: MagnebotDynamic) -> float:
         return self.__angle

--- a/magnebot/actions/turn_to.py
+++ b/magnebot/actions/turn_to.py
@@ -16,13 +16,15 @@ class TurnTo(Turn):
     """
 
     def __init__(self, target: Union[int, Dict[str, float], np.array], resp: List[bytes], dynamic: MagnebotDynamic,
-                 collision_detection: CollisionDetection, aligned_at: float = 1, previous: Action = None):
+                 collision_detection: CollisionDetection, set_torso: bool, aligned_at: float = 1,
+                 previous: Action = None):
         """
         :param target: The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         :param resp: The response from the build.
         :param aligned_at: If the difference between the current angle and the target angle is less than this value, then the action is successful.
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         :param collision_detection: [The collision detection rules.](../collision_detection.md)
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         :param previous: The previous action, if any.
         """
 
@@ -52,7 +54,7 @@ class TurnTo(Turn):
         else:
             raise Exception(f"Invalid target: {target}")
         super().__init__(aligned_at=aligned_at, dynamic=dynamic, collision_detection=collision_detection,
-                         previous=previous)
+                         set_torso=set_torso, previous=previous)
 
     def _get_angle(self, dynamic: MagnebotDynamic) -> float:
         return TDWUtils.get_angle_between(v1=dynamic.transform.forward,

--- a/magnebot/actions/wheel_motion.py
+++ b/magnebot/actions/wheel_motion.py
@@ -57,14 +57,16 @@ class WheelMotion(Action, ABC):
                                                                    static=static, dynamic=dynamic)
         # Make the robot moveable.
         if dynamic.immovable:
-            self._resetting = True
+            self._resetting = True                        
             commands.extend([{"$type": "set_immovable",
                               "id": static.robot_id,
                               "immovable": False},
-                             {"$type": "set_prismatic_target",
-                              "joint_id": static.arm_joints[ArmJoint.torso],
-                              "target": 1,
-                              "id": static.robot_id},
+                             # Prevent the torso from moving when move_by is called
+                             # it by removing the following
+                             #{"$type": "set_prismatic_target",
+                             # "joint_id": static.arm_joints[ArmJoint.torso],
+                             # "target": 1,
+                             # "id": static.robot_id},
                              {"$type": "set_revolute_target",
                               "joint_id": static.arm_joints[ArmJoint.column],
                               "target": 0,

--- a/magnebot/actions/wheel_motion.py
+++ b/magnebot/actions/wheel_motion.py
@@ -17,10 +17,12 @@ class WheelMotion(Action, ABC):
     Abstract base class for a motion action involving the Magnebot's wheels.
     """
 
-    def __init__(self, dynamic: MagnebotDynamic, collision_detection: CollisionDetection, previous: Action = None):
+    def __init__(self, dynamic: MagnebotDynamic, collision_detection: CollisionDetection, set_torso: bool,
+                 previous: Action = None):
         """
         :param dynamic: [The dynamic Magnebot data.](../magnebot_dynamic.md)
         :param collision_detection: [The collision detection rules.](../collision_detection.md)
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         :param previous: The previous action, if any.
         """
 
@@ -28,6 +30,7 @@ class WheelMotion(Action, ABC):
         # My collision detection rules.
         self._collision_detection: CollisionDetection = collision_detection
         self._resetting: bool = False
+        self._set_torso: bool = set_torso
         # Immediately end the action if we're currently tipping.
         has_tipped, is_tipping = self._is_tipping(dynamic=dynamic)
         if has_tipped:
@@ -57,20 +60,21 @@ class WheelMotion(Action, ABC):
                                                                    static=static, dynamic=dynamic)
         # Make the robot moveable.
         if dynamic.immovable:
-            self._resetting = True                        
-            commands.extend([{"$type": "set_immovable",
+            self._resetting = True
+            commands.append({"$type": "set_immovable",
                               "id": static.robot_id,
-                              "immovable": False},
-                             # Prevent the torso from moving when move_by is called
-                             # it by removing the following
-                             #{"$type": "set_prismatic_target",
-                             # "joint_id": static.arm_joints[ArmJoint.torso],
-                             # "target": 1,
-                             # "id": static.robot_id},
-                             {"$type": "set_revolute_target",
-                              "joint_id": static.arm_joints[ArmJoint.column],
-                              "target": 0,
-                              "id": static.robot_id}])
+                              "immovable": False})
+            # Maybe reset the torso.
+            if self._set_torso:
+                commands.append({"$type": "set_prismatic_target",
+                                 "joint_id": static.arm_joints[ArmJoint.torso],
+                                 "target": 1,
+                                 "id": static.robot_id})
+            # Always reset the column.
+            commands.append({"$type": "set_revolute_target",
+                             "joint_id": static.arm_joints[ArmJoint.column],
+                             "target": 0,
+                             "id": static.robot_id})
         # Reset the drive values.
         for wheel_id in static.wheels.values():
             drive = static.joints[wheel_id].drives["x"]

--- a/magnebot/constants.py
+++ b/magnebot/constants.py
@@ -29,4 +29,4 @@ DEFAULT_CAMERA_POSITION_TORSO: Dict[str, float] = {"x": 0, "y": 0.053, "z": 0.18
 # The default camera position if the camera is parented to the column.
 DEFAULT_CAMERA_POSITION_COLUMN: Dict[str, float] = {"x": 0, "y": 0.6324, "z": 0.1838}
 # The required TDW version.
-TDW_VERSION: str = "1.11.0"
+TDW_VERSION: str = "1.11.3"

--- a/magnebot/magnebot.py
+++ b/magnebot/magnebot.py
@@ -325,7 +325,7 @@ class Magnebot(RobotBase):
                 # Remember the previous action.
                 self._previous_action = deepcopy(self.action)
 
-    def turn_by(self, angle: float, aligned_at: float = 1) -> None:
+    def turn_by(self, angle: float, aligned_at: float = 1, set_torso: bool = True) -> None:
         """
         Turn the Magnebot by an angle.
 
@@ -333,12 +333,14 @@ class Magnebot(RobotBase):
 
         :param angle: The target angle in degrees. Positive value = clockwise turn.
         :param aligned_at: If the difference between the current angle and the target angle is less than this value, then the action is successful.
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         """
 
         self.action = TurnBy(angle=angle, aligned_at=aligned_at, collision_detection=self.collision_detection,
-                             previous=self._previous_action, dynamic=self.dynamic)
+                             previous=self._previous_action, dynamic=self.dynamic, set_torso=set_torso)
 
-    def turn_to(self, target: Union[int, Dict[str, float], np.ndarray], aligned_at: float = 1) -> None:
+    def turn_to(self, target: Union[int, Dict[str, float], np.ndarray], aligned_at: float = 1,
+                set_torso: bool = True) -> None:
         """
         Turn the Magnebot to face a target object or position.
 
@@ -346,25 +348,27 @@ class Magnebot(RobotBase):
 
         :param target: The target. If int: An object ID. If dict: A position as an x, y, z dictionary. If numpy array: A position as an [x, y, z] numpy array.
         :param aligned_at: If the difference between the current angle and the target angle is less than this value, then the action is successful.
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         """
 
         self.action = TurnTo(target=target, resp=self._previous_resp, aligned_at=aligned_at,
                              collision_detection=self.collision_detection, previous=self._previous_action,
-                             dynamic=self.dynamic)
+                             dynamic=self.dynamic, set_torso=set_torso)
 
-    def move_by(self, distance: float, arrived_at: float = 0.1) -> None:
+    def move_by(self, distance: float, arrived_at: float = 0.1, set_torso: bool = True) -> None:
         """
         Move the Magnebot forward or backward by a given distance.
 
         :param distance: The target distance. If less than zero, the Magnebot will move backwards.
         :param arrived_at: If at any point during the action the difference between the target distance and distance traversed is less than this, then the action is successful.
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         """
 
         self.action = MoveBy(distance=distance, arrived_at=arrived_at, collision_detection=self.collision_detection,
-                             previous=self._previous_action, dynamic=self.dynamic)
+                             previous=self._previous_action, dynamic=self.dynamic, set_torso=set_torso)
 
     def move_to(self, target: Union[int, Dict[str, float], np.ndarray], arrived_at: float = 0.1, aligned_at: float = 1,
-                arrived_offset: float = 0) -> None:
+                arrived_offset: float = 0, set_torso: bool = True) -> None:
         """
         Move to a target object or position. This combines turn_to() followed by move_by().
 
@@ -372,11 +376,12 @@ class Magnebot(RobotBase):
         :param arrived_at: If at any point during the action the difference between the target distance and distance traversed is less than this, then the action is successful.
         :param aligned_at: If the difference between the current angle and the target angle is less than this value, then the action is successful.
         :param arrived_offset: Offset the arrival position by this value. This can be useful if the Magnebot needs to move to an object but shouldn't try to move to the object's centroid. This is distinct from `arrived_at` because it won't affect the Magnebot's braking solution.
+        :param set_torso: If True, slide the torso to its default position when the wheel motion begins.
         """
 
         self.action = MoveTo(target=target, resp=self._previous_resp, dynamic=self.dynamic,
                              collision_detection=self.collision_detection, arrived_at=arrived_at, aligned_at=aligned_at,
-                             arrived_offset=arrived_offset, previous=self._previous_action)
+                             arrived_offset=arrived_offset, previous=self._previous_action, set_torso=set_torso)
 
     def stop(self) -> None:
         """
@@ -387,7 +392,8 @@ class Magnebot(RobotBase):
 
     def reach_for(self, target: Union[Dict[str, float], np.ndarray], arm: Arm, absolute: bool = True,
                   orientation_mode: OrientationMode = OrientationMode.auto,
-                  target_orientation: TargetOrientation = TargetOrientation.auto, arrived_at: float = 0.125) -> None:
+                  target_orientation: TargetOrientation = TargetOrientation.auto, arrived_at: float = 0.125,
+                  set_torso: bool = True) -> None:
         """
         Reach for a target position. The action ends when the magnet is at or near the target position, or if it fails to reach the target.
         The Magnebot may try to reach for the target multiple times, trying different IK orientations each time, or no times, if it knows the action will fail.
@@ -398,16 +404,18 @@ class Magnebot(RobotBase):
         :param arrived_at: If the magnet is this distance or less from `target`, then the action is successful.
         :param orientation_mode: [The orientation mode.](ik/orientation_mode.md)
         :param target_orientation: [The target orientation.](ik/target_orientation.md)
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         """
 
         if isinstance(target, dict):
             target = TDWUtils.vector3_to_array(target)
 
         self.action = ReachFor(target=target, arm=arm, absolute=absolute, orientation_mode=orientation_mode,
-                               target_orientation=target_orientation, arrived_at=arrived_at, dynamic=self.dynamic)
+                               target_orientation=target_orientation, arrived_at=arrived_at, dynamic=self.dynamic,
+                               set_torso=set_torso)
 
     def grasp(self, target: int, arm: Arm, orientation_mode: OrientationMode = OrientationMode.auto,
-              target_orientation: TargetOrientation = TargetOrientation.auto, set_torso_at_end: bool = True) -> None:
+              target_orientation: TargetOrientation = TargetOrientation.auto, set_torso: bool = True) -> None:
         """
         Try to grasp a target object.
         The action ends when either the Magnebot grasps the object, can't grasp it, or fails arm articulation.
@@ -416,35 +424,35 @@ class Magnebot(RobotBase):
         :param arm: [The arm that will reach for and grasp the target.](arm.md)
         :param orientation_mode: [The orientation mode.](ik/orientation_mode.md)
         :param target_orientation: [The target orientation.](ik/target_orientation.md)
-        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         """
 
         self.action = Grasp(target=target, arm=arm, orientation_mode=orientation_mode,
                             target_orientation=target_orientation, dynamic=self.dynamic,
-                            set_torso_at_end=set_torso_at_end)
+                            set_torso=set_torso)
 
-    def drop(self, target: int, arm: Arm, wait_for_object: bool = True, set_torso_at_end: bool = True) -> None:
+    def drop(self, target: int, arm: Arm, wait_for_object: bool = True, set_torso: bool = True) -> None:
         """
         Drop an object held by a magnet.
 
         :param target: The ID of the object currently held by the magnet.
         :param arm: [The arm of the magnet holding the object.](arm.md)
         :param wait_for_object: If True, the action will continue until the object has finished falling. If False, the action advances the simulation by exactly 1 frame.
-        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         """
 
         self.action = Drop(arm=arm, target=target, wait_for_object=wait_for_object, dynamic=self.dynamic,
-                           set_torso_at_end=set_torso_at_end)
+                           set_torso=set_torso)
 
-    def reset_arm(self, arm: Arm, set_torso_at_end: bool = True) -> None:
+    def reset_arm(self, arm: Arm, set_torso: bool = True) -> None:
         """
         Reset an arm to its neutral position.
 
         :param arm: [The arm to reset.](arm.md)
-        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
+        :param set_torso: If True, stop sliding the torso when the arms stop moving at the end of the action.
         """
 
-        self.action = ResetArm(arm=arm, set_torso_at_end=set_torso_at_end)
+        self.action = ResetArm(arm=arm, set_torso=set_torso)
 
     def reset_position(self) -> None:
         """

--- a/magnebot/magnebot.py
+++ b/magnebot/magnebot.py
@@ -407,7 +407,7 @@ class Magnebot(RobotBase):
                                target_orientation=target_orientation, arrived_at=arrived_at, dynamic=self.dynamic)
 
     def grasp(self, target: int, arm: Arm, orientation_mode: OrientationMode = OrientationMode.auto,
-              target_orientation: TargetOrientation = TargetOrientation.auto) -> None:
+              target_orientation: TargetOrientation = TargetOrientation.auto, set_torso_at_end: bool = True) -> None:
         """
         Try to grasp a target object.
         The action ends when either the Magnebot grasps the object, can't grasp it, or fails arm articulation.
@@ -416,30 +416,35 @@ class Magnebot(RobotBase):
         :param arm: [The arm that will reach for and grasp the target.](arm.md)
         :param orientation_mode: [The orientation mode.](ik/orientation_mode.md)
         :param target_orientation: [The target orientation.](ik/target_orientation.md)
+        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
         """
 
         self.action = Grasp(target=target, arm=arm, orientation_mode=orientation_mode,
-                            target_orientation=target_orientation, dynamic=self.dynamic)
+                            target_orientation=target_orientation, dynamic=self.dynamic,
+                            set_torso_at_end=set_torso_at_end)
 
-    def drop(self, target: int, arm: Arm, wait_for_object: bool = True) -> None:
+    def drop(self, target: int, arm: Arm, wait_for_object: bool = True, set_torso_at_end: bool = True) -> None:
         """
         Drop an object held by a magnet.
 
         :param target: The ID of the object currently held by the magnet.
         :param arm: [The arm of the magnet holding the object.](arm.md)
         :param wait_for_object: If True, the action will continue until the object has finished falling. If False, the action advances the simulation by exactly 1 frame.
+        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
         """
 
-        self.action = Drop(arm=arm, target=target, wait_for_object=wait_for_object, dynamic=self.dynamic)
+        self.action = Drop(arm=arm, target=target, wait_for_object=wait_for_object, dynamic=self.dynamic,
+                           set_torso_at_end=set_torso_at_end)
 
-    def reset_arm(self, arm: Arm) -> None:
+    def reset_arm(self, arm: Arm, set_torso_at_end: bool = True) -> None:
         """
         Reset an arm to its neutral position.
 
         :param arm: [The arm to reset.](arm.md)
+        :param set_torso_at_end: If True, set the position of the torso when the arms stop moving at the end of the action.
         """
 
-        self.action = ResetArm(arm=arm)
+        self.action = ResetArm(arm=arm, set_torso_at_end=set_torso_at_end)
 
     def reset_position(self) -> None:
         """

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ readme = re.sub(r'\[(.*?)\]\(doc/(.*?)\)', r'[\1][https://github.com/alters-mit/
 
 setup(
     name='magnebot',
-    version="2.2.2",
+    version="2.2.3",
     description='High-level API for the Magnebot in TDW.',
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ setup(
     keywords='unity simulation tdw robotics',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['tdw>=1.11.0.0', 'numpy', 'requests', 'matplotlib', 'pillow', "py_md_doc", "tqdm", "scipy", "ikpy==3.1",
+    install_requires=['tdw>=1.11.3.0', 'numpy', 'requests', 'matplotlib', 'pillow', "py_md_doc", "tqdm", "scipy", "ikpy==3.1",
                       "overrides"],
 )


### PR DESCRIPTION
- In `Magnebot`, added optional parameter `set_torso` to `drop()`, `grasp()`, `reach_for()`, and `reset_arm()`. The default value is True. If False, the torso won't be set at the *end* of the action.
- In `Magnebot`, added optional parameter `set_torso` to `move_by()`, `move_to()`, `turn_by()`, and `turn_to()`. The default value is True. If False the torso won't slide to its default position at the *start* of the action.
- `magnebot.slide_torso()` no longer sets the torso position at the end of the action.
- Updated documentation to explain the `set_torso` parameter:
  - `manual/magnebot/arm_articulation.md`
  - `manual/magnebot/grasp.md`
  - `manual/magnebot/movement.md`