### PR TITLE
Fixed: fail to turn due to low force limit

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.11
+
+- Fixed: The Magnebot fails to move or turn when its torso is higher than the default height. `WheelMotion` now sets force limits based on the height of the torso if `set_torso=False`. 
+
 ## 2.2.10
 
 - Fixed: Spherecast in `grasp` always targets the object at index 0 instead of the target object.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ readme = re.sub(r'\[(.*?)\]\(doc/(.*?)\)', r'[\1][https://github.com/alters-mit/
 
 setup(
     name='magnebot',
-    version="2.2.10",
+    version="2.2.11",
     description='High-level API for the Magnebot in TDW.',
     long_description=readme,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
- Fixed: The Magnebot fails to move or turn when its torso is higher than the default height. `WheelMotion` now sets force limits based on the height of the torso if `set_torso=False`. 